### PR TITLE
feat/passport verification

### DIFF
--- a/src/attestable_builds/cli.py
+++ b/src/attestable_builds/cli.py
@@ -8,7 +8,7 @@ import typer
 from .build import run_cargo_build
 from .cargo import hash_cargo_lock, parse_cargo_lock, verify_all
 from .git import get_git_info
-from .passport import generate_passport, hash_binary
+from .passport import generate_passport, verify_passport
 from .toolchain import get_toolchain_info
 
 app = typer.Typer(help="Build-time verification and attestation for TEE deployments")
@@ -209,6 +209,168 @@ def build(
         raise typer.Exit(1)
 
 
+@app.command()
+def verify(
+    passport: Path = typer.Argument(
+        ...,
+        help="Path to passport JSON file",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+    ),
+    manifest: Path = typer.Option(
+        None,
+        "--manifest",
+        "-m",
+        help="Path to verification manifest JSON file",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+    ),
+    project_dir: Path = typer.Option(
+        None,
+        "--project-dir",
+        "-p",
+        help="Path to project directory (for git commit and Cargo.lock verification)",
+        exists=True,
+        file_okay=False,
+    ),
+    binary: Path = typer.Option(
+        None,
+        "--binary",
+        "-b",
+        help="Path to binary artifact to verify",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+    ),
+    strict: bool = typer.Option(
+        False,
+        "--strict",
+        help="Fail if any optional checks cannot be performed",
+    ),
+):
+    """Verify a passport document against known values.
+
+    Verification can be done via:
+    1. Verification manifest file (--manifest): A JSON file containing expected values
+    2. Project directory (--project-dir): Gathers git commit and Cargo.lock from project
+    3. Individual values (--binary): Direct specification of values to check
+
+    This command verifies:
+    - Passport format and structure
+    - Git commit hash (from manifest or project directory)
+    - Git tree hash (from manifest)
+    - Cargo.lock hash (from manifest or project directory)
+    - Input merkle root (from manifest)
+    - Toolchain binary hashes - rustc and cargo (from manifest)
+    - Binary artifact hashes (from manifest or --binary)
+    """
+    try:
+        print("=" * 60)
+        print("Passport Verification")
+        print("=" * 60)
+
+        # Gather verification inputs
+        git_commit = None
+        cargo_lock_hash = None
+
+        if manifest:
+            print(f"\n[1/2] Loading verification manifest: {manifest.name}")
+        elif project_dir:
+            print(f"\n[1/2] Gathering verification data from project...")
+            # Get git commit
+            git_info = get_git_info(project_dir)
+            if git_info:
+                git_commit = git_info["commit_hash"]
+                print(f"  ✓ Git commit: {git_commit[:8]}...")
+            else:
+                print(f"  ⊘ Not a git repository")
+
+            # Get Cargo.lock hash
+            cargo_lock = project_dir / "Cargo.lock"
+            if cargo_lock.exists():
+                cargo_lock_hash = hash_cargo_lock(cargo_lock)
+                print(f"  ✓ Cargo.lock hash: {cargo_lock_hash[:16]}...")
+            else:
+                print(f"  ⊘ Cargo.lock not found")
+
+        print(f"\n[2/2] Verifying passport: {passport.name}")
+
+        # Run verification
+        results = verify_passport(
+            passport_path=passport,
+            manifest_path=manifest,
+            git_commit=git_commit,
+            cargo_lock_hash=cargo_lock_hash,
+            binary_path=binary,
+            strict=strict,
+        )
+
+        # Print results
+        print(f"\n{'=' * 60}")
+        print(f"Verification Results")
+        print(f"{'=' * 60}\n")
+
+        # Show passport metadata
+        if results["passport"]:
+            passport_data = results["passport"]
+            print(f"Passport Version: {passport_data.get('version', 'unknown')}")
+            if passport_data.get("build_process", {}).get("timestamp"):
+                print(f"Build Timestamp: {passport_data['build_process']['timestamp']}")
+            print(f"\n{'=' * 60}\n")
+
+        # Display check results
+        passed_checks = []
+        failed_checks = []
+        skipped_checks = []
+
+        for check_name, check_result in results["checks"].items():
+            if check_result["passed"]:
+                passed_checks.append((check_name, check_result["message"]))
+            else:
+                # Check if it's a skip (not a failure)
+                if "skipped" in check_result["message"].lower() or "no " in check_result["message"].lower():
+                    skipped_checks.append((check_name, check_result["message"]))
+                else:
+                    failed_checks.append((check_name, check_result["message"]))
+
+        # Show passed checks
+        if passed_checks:
+            print("PASSED:")
+            for name, message in passed_checks:
+                print(f"  ✓ {name.replace('_', ' ').title()}")
+                print(f"    {message}")
+
+        # Show failed checks
+        if failed_checks:
+            print("\nFAILED:")
+            for name, message in failed_checks:
+                print(f"  ✗ {name.replace('_', ' ').title()}")
+                print(f"    {message}")
+
+        # Show skipped checks
+        if skipped_checks:
+            print("\nSKIPPED:")
+            for name, message in skipped_checks:
+                print(f"  ⊘ {name.replace('_', ' ').title()}")
+                print(f"    {message}")
+
+        print(f"\n{'=' * 60}")
+        if results["valid"]:
+            print("✓ Passport verification PASSED")
+        else:
+            print("✗ Passport verification FAILED")
+        print("=" * 60)
+
+        if not results["valid"]:
+            raise typer.Exit(1)
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        raise typer.Exit(1)
 
 
 

--- a/src/attestable_builds/passport.py
+++ b/src/attestable_builds/passport.py
@@ -126,3 +126,444 @@ def generate_passport(
 def hash_binary(binary_path: Path) -> str:
     """Calculate SHA256 hash of a binary file."""
     return hashlib.sha256(binary_path.read_bytes()).hexdigest()
+
+
+def _load_passport(passport_path: Path) -> tuple[Optional[dict], Optional[dict]]:
+    """Load and validate passport structure.
+
+    Returns:
+        Tuple of (passport_data, error_check) where error_check is None on success.
+    """
+    try:
+        passport = json.loads(passport_path.read_text())
+    except Exception as e:
+        return None, {"passed": False, "message": f"Failed to load passport: {e}"}
+
+    required_fields = ["version", "inputs", "build_process"]
+    missing_fields = [f for f in required_fields if f not in passport]
+    if missing_fields:
+        return None, {
+            "passed": False,
+            "message": f"Missing required fields: {', '.join(missing_fields)}",
+        }
+
+    return passport, None
+
+
+def _verify_git_commit(passport: dict, expected_commit: str, strict: bool) -> dict:
+    """Verify git commit hash matches expected value."""
+    passport_commit = passport.get("inputs", {}).get("source", {}).get("commit_hash")
+
+    if not passport_commit:
+        return {
+            "passed": False,
+            "message": "No git commit in passport",
+            "fail": strict,
+        }
+
+    if passport_commit == expected_commit:
+        return {
+            "passed": True,
+            "message": f"Git commit matches: {expected_commit[:8]}...",
+        }
+
+    return {
+        "passed": False,
+        "message": f"Git commit mismatch: expected {expected_commit[:8]}..., got {passport_commit[:8]}...",
+        "fail": True,
+    }
+
+
+def _verify_git_tree(passport: dict, expected_tree: str, strict: bool) -> dict:
+    """Verify git tree hash matches expected value."""
+    passport_tree = passport.get("inputs", {}).get("source", {}).get("tree_hash")
+
+    if not passport_tree:
+        return {
+            "passed": False,
+            "message": "No git tree in passport",
+            "fail": strict,
+        }
+
+    if passport_tree == expected_tree:
+        return {
+            "passed": True,
+            "message": f"Git tree matches: {expected_tree[:8]}...",
+        }
+
+    return {
+        "passed": False,
+        "message": f"Git tree mismatch: expected {expected_tree[:8]}..., got {passport_tree[:8]}...",
+        "fail": True,
+    }
+
+
+def _verify_input_merkle_root(passport: dict, expected_root: str, strict: bool) -> dict:
+    """Verify input merkle root matches expected value."""
+    passport_root = passport.get("inputs", {}).get("input_merkle_root")
+
+    if not passport_root:
+        return {
+            "passed": False,
+            "message": "No input merkle root in passport",
+            "fail": strict,
+        }
+
+    if passport_root == expected_root:
+        return {
+            "passed": True,
+            "message": f"Input merkle root matches: {expected_root[:16]}...",
+        }
+
+    return {
+        "passed": False,
+        "message": f"Input merkle root mismatch: expected {expected_root[:16]}..., got {passport_root[:16]}...",
+        "fail": True,
+    }
+
+
+def _verify_toolchain_hashes(
+    passport: dict, rustc_hash: Optional[str], cargo_hash: Optional[str], strict: bool
+) -> dict:
+    """Verify toolchain binary hashes match expected values."""
+    toolchain = passport.get("inputs", {}).get("toolchain", {})
+    passport_rustc = toolchain.get("rustc", {}).get("binary_hash")
+    passport_cargo = toolchain.get("cargo", {}).get("binary_hash")
+
+    checks = []
+    all_passed = True
+
+    if rustc_hash:
+        if not passport_rustc:
+            if strict:
+                all_passed = False
+            checks.append(f"rustc: not in passport")
+        elif passport_rustc == rustc_hash:
+            checks.append(f"rustc: {rustc_hash[:8]}... ✓")
+        else:
+            all_passed = False
+            checks.append(
+                f"rustc: expected {rustc_hash[:8]}..., got {passport_rustc[:8]}..."
+            )
+
+    if cargo_hash:
+        if not passport_cargo:
+            if strict:
+                all_passed = False
+            checks.append(f"cargo: not in passport")
+        elif passport_cargo == cargo_hash:
+            checks.append(f"cargo: {cargo_hash[:8]}... ✓")
+        else:
+            all_passed = False
+            checks.append(
+                f"cargo: expected {cargo_hash[:8]}..., got {passport_cargo[:8]}..."
+            )
+
+    if not checks:
+        return {
+            "passed": False,
+            "message": "No toolchain hashes provided",
+            "fail": strict,
+        }
+
+    return {
+        "passed": all_passed,
+        "message": "; ".join(checks),
+        "fail": not all_passed,
+    }
+
+
+def _verify_cargo_lock(passport: dict, expected_hash: str, strict: bool) -> dict:
+    """Verify Cargo.lock hash matches expected value."""
+    passport_hash = passport.get("inputs", {}).get("cargo_lock_hash")
+
+    if not passport_hash:
+        return {
+            "passed": False,
+            "message": "No Cargo.lock hash in passport",
+            "fail": strict,
+        }
+
+    if passport_hash == expected_hash:
+        return {"passed": True, "message": "Cargo.lock hash matches"}
+
+    return {
+        "passed": False,
+        "message": "Cargo.lock hash mismatch",
+        "fail": True,
+    }
+
+
+def _verify_binary_hash(passport: dict, binary_path: Path, strict: bool) -> dict:
+    """Verify binary artifact hash matches passport record."""
+    if not binary_path.exists():
+        return {
+            "passed": False,
+            "message": f"Binary not found: {binary_path}",
+            "fail": True,
+        }
+
+    actual_hash = hash_binary(binary_path)
+    artifacts = passport.get("outputs", {}).get("artifacts", [])
+    binary_name = binary_path.name
+
+    # Find matching artifact by name
+    matching_artifact = next(
+        (a for a in artifacts if a.get("name") == binary_name), None
+    )
+
+    if not matching_artifact:
+        return {
+            "passed": False,
+            "message": f"No artifact named '{binary_name}' in passport",
+            "fail": strict,
+        }
+
+    expected_hash = matching_artifact.get("hash")
+    if actual_hash == expected_hash:
+        return {
+            "passed": True,
+            "message": f"Binary hash matches: {actual_hash[:16]}...",
+        }
+
+    return {
+        "passed": False,
+        "message": f"Binary hash mismatch: expected {expected_hash[:16]}..., got {actual_hash[:16]}...",
+        "fail": True,
+    }
+
+
+def _verify_input_merkle(passport: dict, strict: bool) -> dict:
+    """Verify input merkle root by recalculating from passport data."""
+    try:
+        inputs = passport.get("inputs", {})
+        source = inputs.get("source", {})
+        toolchain = inputs.get("toolchain", {})
+        dependencies = inputs.get("dependencies", [])
+
+        computed_root = calculate_input_merkle_root(
+            git_commit_hash=source.get("commit_hash"),
+            git_tree_hash=source.get("tree_hash"),
+            git_binary_hash=source.get("git_binary_hash"),
+            cargo_lock_hash=inputs.get("cargo_lock_hash"),
+            dependencies=[
+                {
+                    "name": dep["name"],
+                    "version": dep["version"],
+                    "checksum": dep["checksum"],
+                }
+                for dep in dependencies
+            ]
+            if dependencies
+            else [],
+            toolchain={
+                "rustc": {
+                    "binary_hash": toolchain.get("rustc", {}).get("binary_hash"),
+                    "version": toolchain.get("rustc", {}).get("version"),
+                },
+                "cargo": {
+                    "binary_hash": toolchain.get("cargo", {}).get("binary_hash"),
+                    "version": toolchain.get("cargo", {}).get("version"),
+                },
+            },
+        )
+
+        expected_root = inputs.get("input_merkle_root")
+        if computed_root == expected_root:
+            return {
+                "passed": True,
+                "message": f"Input merkle root verified: {computed_root[:16]}...",
+            }
+
+        expected_str = expected_root[:16] if expected_root else "None"
+        return {
+            "passed": False,
+            "message": f"Input merkle root mismatch: expected {expected_str}..., computed {computed_root[:16]}...",
+            "fail": True,
+        }
+    except Exception as e:
+        return {
+            "passed": False,
+            "message": f"Failed to verify input merkle root: {e}",
+            "fail": strict,
+        }
+
+
+def load_verification_manifest(manifest_path: Path) -> dict:
+    """Load a verification manifest JSON file.
+
+    Manifest format:
+    {
+        "git_commit": "abc123...",
+        "git_tree": "def456...",
+        "cargo_lock_hash": "ghi789...",
+        "input_merkle_root": "jkl012...",
+        "toolchain": {
+            "rustc_hash": "mno345...",
+            "cargo_hash": "pqr678..."
+        },
+        "binary_artifacts": [
+            {"name": "my-app", "hash": "stu901..."}
+        ]
+    }
+
+    Args:
+        manifest_path: Path to verification manifest JSON file
+
+    Returns:
+        Dictionary containing expected values for verification
+    """
+    try:
+        return json.loads(manifest_path.read_text())
+    except Exception as e:
+        raise ValueError(f"Failed to load verification manifest: {e}")
+
+
+def verify_passport(
+    passport_path: Path,
+    manifest_path: Optional[Path] = None,
+    git_commit: Optional[str] = None,
+    cargo_lock_hash: Optional[str] = None,
+    binary_path: Optional[Path] = None,
+    strict: bool = False,
+) -> dict:
+    """Verify a passport document against known values.
+
+    Args:
+        passport_path: Path to passport JSON file
+        manifest_path: Path to verification manifest JSON (optional, takes precedence)
+        git_commit: Expected git commit hash (optional)
+        cargo_lock_hash: Expected Cargo.lock hash (optional)
+        binary_path: Path to binary to verify hash (optional)
+        strict: If True, fail if any optional check cannot be performed
+
+    Returns:
+        Dictionary with verification results:
+        {
+            "valid": bool,
+            "checks": {
+                "passport_format": {"passed": bool, "message": str},
+                "git_commit": {"passed": bool, "message": str},
+                "cargo_lock": {"passed": bool, "message": str},
+                "binary_hash": {"passed": bool, "message": str},
+                "input_merkle": {"passed": bool, "message": str},
+            },
+            "passport": dict  # The loaded passport data
+        }
+    """
+    results = {"valid": True, "checks": {}, "passport": None}
+
+    # Load and validate passport structure
+    passport, error = _load_passport(passport_path)
+    if error or passport is None:
+        results["valid"] = False
+        results["checks"]["passport_format"] = error or {
+            "passed": False,
+            "message": "Unknown error loading passport",
+        }
+        return results
+
+    results["passport"] = passport
+    results["checks"]["passport_format"] = {
+        "passed": True,
+        "message": "Passport loaded successfully",
+    }
+
+    # Load verification manifest if provided
+    manifest = None
+    git_tree = None
+    input_merkle_root = None
+    rustc_hash = None
+    cargo_hash = None
+
+    if manifest_path:
+        try:
+            manifest = load_verification_manifest(manifest_path)
+            git_commit = git_commit or manifest.get("git_commit")
+            git_tree = manifest.get("git_tree")
+            cargo_lock_hash = cargo_lock_hash or manifest.get("cargo_lock_hash")
+            input_merkle_root = manifest.get("input_merkle_root")
+
+            # Extract toolchain hashes
+            toolchain = manifest.get("toolchain", {})
+            rustc_hash = toolchain.get("rustc_hash")
+            cargo_hash = toolchain.get("cargo_hash")
+        except ValueError as e:
+            results["valid"] = False
+            results["checks"]["manifest_format"] = {
+                "passed": False,
+                "message": str(e),
+            }
+            return results
+
+    # Run optional verifications
+    verifications = [
+        ("git_commit", git_commit, _verify_git_commit),
+        ("git_tree", git_tree, _verify_git_tree),
+        ("cargo_lock", cargo_lock_hash, _verify_cargo_lock),
+        ("binary_hash", binary_path, _verify_binary_hash),
+    ]
+
+    for check_name, value, verify_func in verifications:
+        if value is not None:
+            check_result = verify_func(passport, value, strict)
+            if check_result.pop("fail", False):
+                results["valid"] = False
+            results["checks"][check_name] = check_result
+
+    # Verify input merkle root from manifest if provided
+    if input_merkle_root:
+        check_result = _verify_input_merkle_root(passport, input_merkle_root, strict)
+        if check_result.pop("fail", False):
+            results["valid"] = False
+        results["checks"]["input_merkle_root"] = check_result
+
+    # Verify toolchain hashes from manifest if provided
+    if rustc_hash or cargo_hash:
+        check_result = _verify_toolchain_hashes(passport, rustc_hash, cargo_hash, strict)
+        if check_result.pop("fail", False):
+            results["valid"] = False
+        results["checks"]["toolchain_hashes"] = check_result
+
+    # Verify binary artifacts from manifest if provided
+    if manifest and manifest.get("binary_artifacts"):
+        for expected_artifact in manifest["binary_artifacts"]:
+            artifact_name = expected_artifact.get("name")
+            expected_hash = expected_artifact.get("hash")
+
+            if not artifact_name or not expected_hash:
+                continue
+
+            # Find matching artifact in passport
+            passport_artifacts = passport.get("outputs", {}).get("artifacts", [])
+            matching = next(
+                (a for a in passport_artifacts if a.get("name") == artifact_name), None
+            )
+
+            if matching:
+                actual_hash = matching.get("hash")
+                if actual_hash != expected_hash:
+                    results["valid"] = False
+                    results["checks"][f"artifact_{artifact_name}"] = {
+                        "passed": False,
+                        "message": f"Artifact '{artifact_name}' hash mismatch: expected {expected_hash[:16]}..., got {actual_hash[:16]}...",
+                    }
+                else:
+                    results["checks"][f"artifact_{artifact_name}"] = {
+                        "passed": True,
+                        "message": f"Artifact '{artifact_name}' hash matches",
+                    }
+            elif strict:
+                results["valid"] = False
+                results["checks"][f"artifact_{artifact_name}"] = {
+                    "passed": False,
+                    "message": f"Artifact '{artifact_name}' not found in passport",
+                }
+
+    # Always verify input merkle root
+    merkle_result = _verify_input_merkle(passport, strict)
+    if merkle_result.pop("fail", False):
+        results["valid"] = False
+    results["checks"]["input_merkle"] = merkle_result
+
+    return results


### PR DESCRIPTION
## Add passport verification

Adds a `verify` command to check passports against known values.

### What it does

You can verify a passport by passing:
- A verification manifest (JSON file with expected hashes/commits)
- A project directory (grabs git commit and Cargo.lock automatically)
- Direct values like `--binary` for specific checks

It checks things like git commits, Cargo.lock hashes, toolchain binaries, the input merkle root, and artifact hashes. There's a `--strict` flag if you want it to fail when optional checks can't run.

### Changes

- New `verify` command in the CLI
- Verification manifest loader 
- Helper functions for each verification type (`_verify_git_commit`, `_verify_cargo_lock`, etc.)
- Pretty output showing what passed/failed/skipped

The verification results come back as a dict with a `valid` flag and individual check results, so it's easy to see what went wrong if something fails.