### PR TITLE
feat/inclusion proofs

### DIFF
--- a/src/kettle/cli.py
+++ b/src/kettle/cli.py
@@ -22,6 +22,7 @@ from .passport import generate_passport, verify_build_passport
 from .results import CheckResult
 from .toolchain import get_toolchain_info
 from .utils import hash_passport_to_32bytes
+from .merkle import generate_inclusion_proofs, verify_inclusion_proof_from_data
 
 
 app = typer.Typer(help="Build-time verification and attestation for TEE deployments")
@@ -852,6 +853,129 @@ def tee_build(
     except Exception as e:
         log_error(f"Error: {e}")
         raise typer.Exit(1)
+
+
+@app.command(name="prove-inclusion")
+def prove_inclusion(
+    passport: Path = typer.Argument(
+        ...,
+        help="Path to passport JSON file",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+    ),
+    hashes: list[str] = typer.Argument(
+        ...,
+        help="Hash values to prove inclusion for (supports partial matching)",
+    ),
+    output: Path = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Save proofs to JSON file (default: print to stdout)",
+    ),
+):
+    """Generate and verify Merkle inclusion proofs for hashes in a passport.
+
+    This command both generates proofs that specified hashes are included in
+    the passport's merkle root AND immediately verifies those proofs.
+
+    Supports partial hash matching for convenience (e.g., "abc123" or "serde:1.0").
+
+    Examples:
+        # Prove inclusion of cargo.lock hash
+        attestable-builds prove-inclusion passport.json abc123...
+
+        # Prove multiple hashes
+        attestable-builds prove-inclusion passport.json hash1 hash2 hash3
+
+        # Prove inclusion of a dependency by partial match
+        attestable-builds prove-inclusion passport.json serde:1.0
+
+        # Save proofs to file
+        attestable-builds prove-inclusion passport.json abc123 --output proofs.json
+    """
+    try:
+        log_section("Merkle Inclusion Proof")
+
+        # Load passport
+        log(f"\nLoading passport: {passport}")
+        passport_data = json.loads(passport.read_text())
+
+        log(f"Generating proofs for {len(hashes)} hash(es)...\n")
+
+        # Generate proofs
+        result = generate_inclusion_proofs(passport_data, hashes)
+
+        # Display generation results
+        log(f"Merkle Root: {result['merkle_root']}", style="bold")
+        log(f"Tree Size: {result['tree_size']} leaves\n")
+
+        if result['proofs']:
+            log_success(f"Generated {len(result['proofs'])} proof(s):")
+            for proof in result['proofs']:
+                log(f"\n  Target: {proof['target_hash']}", style="bold")
+                log(f"  Label: {proof['label']}", style="dim")
+                log(f"  Leaf Index: {proof['leaf_index']}", style="dim")
+                log(f"  Leaf Hash: {proof['leaf_value'][:32]}...", style="dim")
+                log(f"  Proof Size: {len(json.dumps(proof['proof']))} bytes", style="dim")
+
+        if result['not_found']:
+            log("\n")
+            log_warning(f"{len(result['not_found'])} hash(es) not found:")
+            for missing in result['not_found']:
+                log(f"  - {missing}", style="dim")
+
+        # Verify the proofs immediately
+        if result['proofs']:
+            log("\n")
+            log_section("Verifying Proofs")
+
+            merkle_root = bytes.fromhex(result['merkle_root'])
+            all_valid = True
+
+            for i, proof in enumerate(result['proofs'], 1):
+                log(f"\n[{i}/{len(result['proofs'])}] {proof['label']}", style="bold")
+                log(f"  Target: {proof['target_hash']}", style="dim")
+
+                is_valid = verify_inclusion_proof_from_data(proof, merkle_root)
+
+                if is_valid:
+                    log_success("  Proof VALID")
+                else:
+                    log_error("  Proof INVALID")
+                    all_valid = False
+
+            # Final verification result
+            log("\n")
+            if all_valid:
+                log_success(f"All {len(result['proofs'])} proof(s) verified successfully")
+            else:
+                log_error("Some proofs failed verification")
+                if output:
+                    output.write_text(json.dumps(result, indent=2))
+                    log_warning(f"Proofs saved to: {output} (contains invalid proofs)")
+                raise typer.Exit(1)
+
+        # Save if requested
+        if output and result['proofs']:
+            output.write_text(json.dumps(result, indent=2))
+            log("\n")
+            log_success(f"Proofs saved to: {output}")
+        elif output:
+            log_warning("No proofs generated, file not saved")
+
+        # Exit with error if some hashes weren't found
+        if result['not_found'] and not result['proofs']:
+            raise typer.Exit(1)
+
+    except json.JSONDecodeError as e:
+        log_error(f"Invalid JSON in passport: {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        log_error(f"Error: {e}")
+        raise typer.Exit(1)
+
 
 def main():
     """Entry point for CLI."""

--- a/src/kettle/merkle.py
+++ b/src/kettle/merkle.py
@@ -1,6 +1,7 @@
 """Merkle tree calculation for input verification using pymerkle."""
 
 from pymerkle import InmemoryTree as MerkleTree
+from pymerkle import verify_inclusion, MerkleProof
 
 
 def calculate_input_merkle_root(
@@ -49,3 +50,184 @@ def calculate_input_merkle_root(
     tree.append_entry(toolchain['cargo']['version'].encode())
 
     return tree.get_state().hex()
+
+
+def rebuild_merkle_tree_from_passport(passport_data: dict) -> MerkleTree:
+    """Rebuild the Merkle tree from passport data in the exact same order.
+
+    Args:
+        passport_data: Complete passport dictionary
+
+    Returns:
+        Reconstructed MerkleTree instance with all entries
+    """
+    tree = MerkleTree(algorithm='sha256')
+    inputs = passport_data['inputs']
+
+    # Add git source info if available (same order as build)
+    if 'source' in inputs and inputs['source']:
+        if 'commit_hash' in inputs['source'] and inputs['source']['commit_hash']:
+            tree.append_entry(inputs['source']['commit_hash'].encode())
+        if 'tree_hash' in inputs['source'] and inputs['source']['tree_hash']:
+            tree.append_entry(inputs['source']['tree_hash'].encode())
+        if 'git_binary_hash' in inputs['source'] and inputs['source']['git_binary_hash']:
+            tree.append_entry(inputs['source']['git_binary_hash'].encode())
+
+    # Add Cargo.lock hash
+    tree.append_entry(inputs['cargo_lock_hash'].encode())
+
+    # Add dependencies (sorted for determinism)
+    for dep in sorted(inputs['dependencies'], key=lambda x: (x['name'], x['version'])):
+        entry = f"{dep['name']}:{dep['version']}:{dep['checksum']}"
+        tree.append_entry(entry.encode())
+
+    # Add toolchain info
+    tree.append_entry(inputs['toolchain']['rustc']['binary_hash'].encode())
+    tree.append_entry(inputs['toolchain']['rustc']['version'].encode())
+    tree.append_entry(inputs['toolchain']['cargo']['binary_hash'].encode())
+    tree.append_entry(inputs['toolchain']['cargo']['version'].encode())
+
+    return tree
+
+
+def _collect_tree_entries(passport_data: dict) -> list[tuple[str, str, bytes]]:
+    """Collect all tree entries in order with labels.
+
+    Args:
+        passport_data: Complete passport dictionary
+
+    Returns:
+        List of tuples: (label, value_string, value_bytes)
+    """
+    entries = []
+    inputs = passport_data['inputs']
+
+    # Collect git source info if available
+    if 'source' in inputs and inputs['source']:
+        if 'commit_hash' in inputs['source'] and inputs['source']['commit_hash']:
+            val = inputs['source']['commit_hash']
+            entries.append(('git_commit_hash', val, val.encode()))
+        if 'tree_hash' in inputs['source'] and inputs['source']['tree_hash']:
+            val = inputs['source']['tree_hash']
+            entries.append(('git_tree_hash', val, val.encode()))
+        if 'git_binary_hash' in inputs['source'] and inputs['source']['git_binary_hash']:
+            val = inputs['source']['git_binary_hash']
+            entries.append(('git_binary_hash', val, val.encode()))
+
+    # Cargo.lock hash
+    val = inputs['cargo_lock_hash']
+    entries.append(('cargo_lock_hash', val, val.encode()))
+
+    # Dependencies (sorted for determinism)
+    for dep in sorted(inputs['dependencies'], key=lambda x: (x['name'], x['version'])):
+        entry_str = f"{dep['name']}:{dep['version']}:{dep['checksum']}"
+        label = f"dependency:{dep['name']}:{dep['version']}"
+        entries.append((label, entry_str, entry_str.encode()))
+
+    # Toolchain info
+    val = inputs['toolchain']['rustc']['binary_hash']
+    entries.append(('rustc_binary_hash', val, val.encode()))
+
+    val = inputs['toolchain']['rustc']['version']
+    entries.append(('rustc_version', val, val.encode()))
+
+    val = inputs['toolchain']['cargo']['binary_hash']
+    entries.append(('cargo_binary_hash', val, val.encode()))
+
+    val = inputs['toolchain']['cargo']['version']
+    entries.append(('cargo_version', val, val.encode()))
+
+    return entries
+
+
+def generate_inclusion_proofs(passport_data: dict, target_hashes: list[str]) -> dict:
+    """Generate Merkle inclusion proofs for multiple hashes in the passport.
+
+    Args:
+        passport_data: Complete passport dictionary
+        target_hashes: List of hash values to prove inclusion for (can be partial matches)
+
+    Returns:
+        Dict with structure:
+        {
+            "merkle_root": str,
+            "tree_size": int,
+            "proofs": [
+                {
+                    "target_hash": str,
+                    "label": str,
+                    "leaf_index": int,
+                    "leaf_value": bytes (hex),
+                    "proof": dict (serialized proof)
+                },
+                ...
+            ],
+            "not_found": [str, ...]  # Hashes that weren't found
+        }
+    """
+    tree = rebuild_merkle_tree_from_passport(passport_data)
+    entries = _collect_tree_entries(passport_data)
+
+    proofs = []
+    not_found = []
+
+    for target_hash in target_hashes:
+        # Find matching entry (supports partial matching)
+        matched_entry = None
+        matched_index = None
+
+        for idx, (label, value_str, value_bytes) in enumerate(entries):
+            if target_hash in value_str or value_str == target_hash:
+                matched_entry = (label, value_str, value_bytes)
+                matched_index = idx
+                break
+
+        if matched_entry is None or matched_index is None:
+            not_found.append(target_hash)
+            continue
+
+        label, value_str, value_bytes = matched_entry
+        # Leaf indices in pymerkle are 1-indexed
+        leaf_index = matched_index + 1
+
+        # Generate inclusion proof
+        # prove_inclusion(leaf_index, tree_size) - prove leaf is in subtree of size tree_size
+        tree_size = tree.get_size()
+        proof = tree.prove_inclusion(leaf_index, tree_size)
+
+        proofs.append({
+            "target_hash": target_hash,
+            "label": label,
+            "leaf_index": leaf_index,
+            "leaf_value": tree.get_leaf(leaf_index).hex(),
+            "proof": proof.serialize()
+        })
+
+    return {
+        "merkle_root": tree.get_state().hex(),
+        "tree_size": tree.get_size(),
+        "proofs": proofs,
+        "not_found": not_found
+    }
+
+
+def verify_inclusion_proof_from_data(proof_data: dict, expected_root: bytes) -> bool:
+    """Verify a single Merkle inclusion proof.
+
+    Args:
+        proof_data: Proof dictionary from generate_inclusion_proofs
+        expected_root: Expected merkle root as bytes
+
+    Returns:
+        True if proof is valid, False otherwise
+    """
+    try:
+        leaf_hash = bytes.fromhex(proof_data['leaf_value'])
+        # Deserialize the proof from dictionary format
+        proof = MerkleProof.deserialize(proof_data['proof'])
+        # verify_inclusion returns None on success, raises exception on failure
+        verify_inclusion(leaf_hash, expected_root, proof)
+        return True
+    except Exception as e:
+        print(f"Verification error: {e}")
+        return False

--- a/verification-manifest.example.json
+++ b/verification-manifest.example.json
@@ -1,16 +1,90 @@
 {
-  "git_commit": "5e92101a8fe716d9d9c4676ba9775e17936abb0c",
-  "git_tree": "b40b914c8332a5aab59b9cadbd129c71a3e0287f",
+  "git_commit": "86957e0e4c5307e347a24976c701152533ed4501",
+  "git_tree": "ce0efdd1efd3dffb6b83f7e3678791f498087a48",
   "cargo_lock_hash": "23b2e23aa04c93c350cac09ac73636e4ecedf564acc7f5d1c40a7e3fcf227c10",
-  "input_merkle_root": "e47367b6cd0aafeaa53de30c062cd27eb9078d605e1e5ce423fb79820eac07a3",
+  "input_merkle_root": "1b2d157e33d46f4101069853d2d63a2ff6f48d3f9129a3758e8b002d33de02d9",
   "toolchain": {
-    "rustc_hash": "cb5d96f4c51e916fbc4fee5bbd3c3bd5030734f170ef50ec1d0dad0e9e9b9943",
-    "cargo_hash": "2f50d54779378980084feb68e77b8ed4d40be9f592a2ce096d797f5421cf9c62"
+    "rustc_hash": "e6abf55ab1859e7c990be77fd593f51661ea99fb2fde626ae9f4108aaa34e7fa",
+    "cargo_hash": "51de284e8bb0d03dcee595a0fb1cb3a952fe9e7e4b953a8b1467b7f71725b561"
   },
-  "binary_artifacts": [
+  "launch_measurement": "0e3b01f2f08a3e4cead3d075d0e2da32778a18b612919b4108d8201fd9ba811ff151af90615383fb4a8fa9a464b79600",
+  "dependencies": [
     {
-      "name": "simple-app",
-      "hash": "466de09978ee4d5a2328d27612f8eedf6fea84aa0bd763e9ccf5df8c6363cfa1"
+      "name": "unicode-ident",
+      "version": "1.0.19",
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "checksum": "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d",
+      "verified": true
+    },
+    {
+      "name": "proc-macro2",
+      "version": "1.0.101",
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "checksum": "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de",
+      "verified": true
+    },
+    {
+      "name": "serde_derive",
+      "version": "1.0.228",
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "checksum": "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79",
+      "verified": true
+    },
+    {
+      "name": "ryu",
+      "version": "1.0.20",
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "checksum": "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f",
+      "verified": true
+    },
+    {
+      "name": "syn",
+      "version": "2.0.107",
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "checksum": "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b",
+      "verified": true
+    },
+    {
+      "name": "serde_core",
+      "version": "1.0.228",
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "checksum": "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad",
+      "verified": true
+    },
+    {
+      "name": "serde",
+      "version": "1.0.228",
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "checksum": "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e",
+      "verified": true
+    },
+    {
+      "name": "quote",
+      "version": "1.0.41",
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "checksum": "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1",
+      "verified": true
+    },
+    {
+      "name": "serde_json",
+      "version": "1.0.145",
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "checksum": "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c",
+      "verified": true
+    },
+    {
+      "name": "itoa",
+      "version": "1.0.15",
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "checksum": "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c",
+      "verified": true
+    },
+    {
+      "name": "memchr",
+      "version": "2.7.6",
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "checksum": "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273",
+      "verified": true
     }
   ]
 }


### PR DESCRIPTION
## Changes Summary

- Added `prove-inclusion` CLI command to generate and verify Merkle inclusion proofs for hashes in passport files
  - Supports partial hash matching
  - Immediately verifies generated proofs
  - Optional JSON output file

- Implemented Merkle proof functions in `merkle.py`
  - Rebuild tree from passport data
  - Generate inclusion proofs for target hashes
  - Verify proofs against expected root
  - Uses pymerkle library

- Updated verification manifest example with new commit hashes, toolchain hashes, merkle root, and expanded dependency list (10 crates with full metadata)