### PR TITLE
feat/nix derivation checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *.so
 .Python
 build/
+kettle-build/
 dist/
 *.egg-info/
 .pytest_cache/

--- a/src/kettle/build.py
+++ b/src/kettle/build.py
@@ -1,6 +1,7 @@
 """Build orchestration for attestable builds."""
 
 import json
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -68,6 +69,7 @@ def run_build_workflow(
     release: bool = True,
     verbose: bool = False,
     attestation: bool = False,
+    shallow: bool = False,
 ) -> None:
     """Complete build workflow.
 
@@ -83,6 +85,7 @@ def run_build_workflow(
         release: Build in release mode (Cargo only)
         verbose: Show verbose output
         attestation: Generate attestation using attest-amd
+        shallow: Use shallow verification (skip derivation graph evaluation)
 
     Raises:
         typer.Exit: If any step fails
@@ -100,13 +103,18 @@ def run_build_workflow(
 
         # Setup output directories
         output_dir = output_dir.resolve()
-        build_dir = output_dir / "build"
+        build_dir = output_dir / "kettle-build"
+
+        # Clean up previous build artifacts to keep git working tree clean
+        if build_dir.exists():
+            shutil.rmtree(build_dir)
+
         build_dir.mkdir(parents=True, exist_ok=True)
         provenance_path = build_dir / "provenance.json"
 
         # Verify inputs
         git_info, lock, _, toolchain_info = verify_inputs(
-            toolchain, project_dir, verbose=verbose
+            toolchain, project_dir, verbose=verbose, shallow=shallow
         )
 
         # Execute build
@@ -143,7 +151,11 @@ def run_build_workflow(
         log_success(f"Manifest: {manifest_path}")
         if git_info:
             log(f"  Source: {git_info['commit_hash'][:8]}...", style="dim")
-        log(f"  Dependencies: {len(lock['deps'])}", style="dim")
+        # Show appropriate dependency count based on evaluation mode
+        if lock.get("fetches"):
+            log(f"  Dependencies: {len(lock['fetches'])} fetches (deep)", style="dim")
+        else:
+            log(f"  Dependencies: {len(lock['deps'])}", style="dim")
         log(f"  Artifacts: {len(build_result['artifacts'])}", style="dim")
 
         # Attestation (optional)

--- a/src/kettle/cli.py
+++ b/src/kettle/cli.py
@@ -50,6 +50,11 @@ def build(
         "-a",
         help="Generate attestation report using attest-amd command",
     ),
+    shallow: bool = typer.Option(
+        False,
+        "--shallow",
+        help="Use shallow verification (flake inputs only, skip derivation graph evaluation for Nix)",
+    ),
 ):
     """Build project with full input verification and output measurement.
 
@@ -61,11 +66,12 @@ def build(
     3. Executes build
     4. Measures output artifacts
     5. Generates SLSA v1.2 provenance
+
     """
     if output is None:
         output = project_dir
 
-    run_build_workflow(project_dir, output, release, verbose, attestation)
+    run_build_workflow(project_dir, output, release, verbose, attestation, shallow)
 
 
 @app.command(name="verify-provenance")

--- a/src/kettle/core.py
+++ b/src/kettle/core.py
@@ -73,7 +73,7 @@ class Toolchain(ABC):
         ...
 
     @abstractmethod
-    def internal_params(self, info: dict, lock_hash: str) -> dict:
+    def internal_params(self, info: dict, lock_hash: str, lock: dict | None = None) -> dict:
         """Build SLSA internalParameters section."""
         ...
 

--- a/src/kettle/provenance/generate.py
+++ b/src/kettle/provenance/generate.py
@@ -54,11 +54,14 @@ def generate(
     if git:
         external_params["source"] = build_source_descriptor(git)
 
-    # Internal parameters (toolchain-specific)
-    internal_params = toolchain.internal_params(info, lock["hash"])
+    # Internal parameters (toolchain-specific, pass full lock for metadata)
+    internal_params = toolchain.internal_params(info, lock["hash"], lock)
 
-    # Resolved dependencies
-    resolved_deps = [toolchain.dep_to_purl(dep) for dep in lock["deps"]]
+    # Resolved dependencies: use fetches if available (deep mode), otherwise deps (shallow)
+    if lock.get("fetches"):
+        resolved_deps = [toolchain.dep_to_purl(fetch) for fetch in lock["fetches"]]
+    else:
+        resolved_deps = [toolchain.dep_to_purl(dep) for dep in lock["deps"]]
 
     # Byproducts
     byproducts = [build_byproduct("input_merkle_root", input_merkle)]
@@ -268,19 +271,32 @@ def _verify_merkle_recalc(provenance: dict, toolchain: Toolchain, project_dir: P
         if not expected:
             return {"verified": False, "message": "No merkle root in provenance"}
 
+        # Detect evaluation mode from provenance to use same mode for verification
+        internal_params = provenance.get("predicate", {}).get("buildDefinition", {}).get("internalParameters", {})
+        evaluation_mode = internal_params.get("evaluation", {}).get("mode", "shallow")
+        deep = evaluation_mode == "deep"
+
         # Recalculate from current state
         try:
             git = get_git_info(project_dir)
         except Exception:
             git = None
 
-        lock = toolchain.parse_lockfile(project_dir)
+        # Parse lockfile with same mode as original build
+        # Handle toolchains that don't support the deep parameter
+        try:
+            lock = toolchain.parse_lockfile(project_dir, deep=deep)
+        except TypeError:
+            # Fallback for toolchains that don't accept deep parameter
+            lock = toolchain.parse_lockfile(project_dir)
+
         info = toolchain.get_info()
         entries = toolchain.merkle_entries(git, lock, info)
         computed = merkle_root(entries)
 
         if computed == expected:
-            return {"verified": True, "message": f"Merkle root verified: {computed[:16]}..."}
+            mode_info = f" (mode={evaluation_mode})" if evaluation_mode == "deep" else ""
+            return {"verified": True, "message": f"Merkle root verified: {computed[:16]}...{mode_info}"}
 
         return {"verified": False, "message": f"Merkle mismatch: {computed[:16]}... vs {expected[:16]}..."}
 

--- a/src/kettle/provenance/verification.py
+++ b/src/kettle/provenance/verification.py
@@ -55,6 +55,7 @@ def verify_inputs(
     project_dir: Path,
     verbose: bool = False,
     strict: bool = True,
+    shallow: bool = False,
 ) -> tuple[dict | None, dict, list[dict], dict]:
     """Verify all build inputs (git, lockfile, dependencies, toolchain).
 
@@ -63,6 +64,7 @@ def verify_inputs(
         project_dir: Path to project directory
         verbose: Show verbose output
         strict: Fail on dirty git tree
+        shallow: Use shallow verification (skip derivation graph evaluation for Nix)
 
     Returns:
         Tuple of (git_info, lock, dep_results, toolchain_info)
@@ -81,9 +83,23 @@ def verify_inputs(
     # [2/4] Lockfile
     log("\n[2/4] Hashing lockfile...")
     try:
-        lock = toolchain.parse_lockfile(project_dir)
+        # Pass deep=not shallow to enable/disable derivation graph evaluation
+        try:
+            lock = toolchain.parse_lockfile(project_dir, deep=not shallow)
+        except TypeError:
+            # Fallback for toolchains that don't accept deep parameter
+            lock = toolchain.parse_lockfile(project_dir)
+
         log_success(f"SHA256: {lock['hash']}")
-        log(f"  {len(lock['deps'])} dependencies", style="dim")
+        log(f"  {len(lock['deps'])} flake inputs", style="dim")
+
+        # Show evaluation mode info for Nix
+        if lock.get("evaluation_mode"):
+            mode = lock["evaluation_mode"]
+            if mode == "deep" and lock.get("fetches"):
+                log(f"  {len(lock['fetches'])} fixed-output derivations (deep evaluation)", style="dim")
+            elif mode == "shallow":
+                log(f"  Using shallow evaluation (flake inputs only)", style="dim")
     except Exception as e:
         log_error(f"Failed to parse lockfile: {e}")
         raise typer.Exit(1)

--- a/src/kettle/toolchains/cargo/toolchain.py
+++ b/src/kettle/toolchains/cargo/toolchain.py
@@ -163,7 +163,7 @@ class CargoToolchain(Toolchain):
             "name": name,
         }
 
-    def internal_params(self, info: dict, lock_hash: str) -> dict:
+    def internal_params(self, info: dict, lock_hash: str, lock: dict | None = None) -> dict:
         """Build SLSA internalParameters section."""
         return {
             "toolchain": {

--- a/src/kettle/toolchains/nix/toolchain.py
+++ b/src/kettle/toolchains/nix/toolchain.py
@@ -5,11 +5,17 @@ import hashlib
 import json
 import shutil
 import subprocess
+import warnings
 from pathlib import Path
 from urllib.parse import quote
 
 from kettle.core import Toolchain
 from kettle.utils import hash_file
+
+
+class NixEvaluationError(Exception):
+    """Raised when nix derivation evaluation fails."""
+    pass
 
 
 class NixToolchain(Toolchain):
@@ -26,12 +32,112 @@ class NixToolchain(Toolchain):
     def detect(self, project_dir: Path) -> bool:
         return (project_dir / "flake.nix").exists()
 
-    def parse_lockfile(self, project_dir: Path) -> dict:
-        """Parse flake.lock and return lockfile info with inputs."""
+    def evaluate_derivation_graph(
+        self, project_dir: Path, output: str = "default", timeout: int = 300
+    ) -> dict:
+        """Evaluate the full derivation graph for a flake output.
+
+        Args:
+            project_dir: Path to project containing flake.nix
+            output: Flake output to evaluate (default: "default")
+            timeout: Evaluation timeout in seconds
+
+        Returns:
+            dict: Derivation graph keyed by derivation path
+
+        Raises:
+            NixEvaluationError: If nix evaluation fails
+        """
+        cmd = ["nix", "derivation", "show", f".#{output}", "--recursive"]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=project_dir,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=timeout,
+            )
+            return json.loads(result.stdout)
+        except subprocess.CalledProcessError as e:
+            raise NixEvaluationError(f"nix derivation show failed: {e.stderr}")
+        except subprocess.TimeoutExpired:
+            raise NixEvaluationError(f"Derivation evaluation timed out after {timeout}s")
+        except json.JSONDecodeError as e:
+            raise NixEvaluationError(f"Failed to parse derivation JSON: {e}")
+        except FileNotFoundError:
+            raise NixEvaluationError("nix command not found")
+
+    def extract_fixed_output_hashes(self, graph: dict) -> list[dict]:
+        """Extract fixed-output derivations from derivation graph.
+
+        Fixed-output derivations (FODs) are identified by presence of
+        'outputHash' in their env section. These represent content-addressed
+        network fetches.
+
+        Args:
+            graph: Derivation graph from evaluate_derivation_graph()
+
+        Returns:
+            list[dict]: Sorted list of fixed-output derivations with:
+                - name: derivation name
+                - drv_path: /nix/store/xxx.drv path
+                - outputHash: content hash
+                - outputHashAlgo: hash algorithm (usually sha256)
+                - outputHashMode: "flat" or "recursive"
+                - url: source URL if available
+                - urls: multiple URLs if available
+        """
+        fetches = []
+
+        for drv_path, drv_data in graph.items():
+            env = drv_data.get("env", {})
+
+            # Fixed-output derivations have outputHash in env
+            if "outputHash" not in env:
+                continue
+
+            fetch = {
+                "name": drv_data.get("name", env.get("name", "unknown")),
+                "drv_path": drv_path,
+                "outputHash": env["outputHash"],
+                "outputHashAlgo": env.get("outputHashAlgo", "sha256"),
+            }
+
+            # Optional fields
+            if "outputHashMode" in env:
+                fetch["outputHashMode"] = env["outputHashMode"]
+            if "url" in env:
+                fetch["url"] = env["url"]
+            if "urls" in env:
+                fetch["urls"] = env["urls"]
+
+            fetches.append(fetch)
+
+        # Sort by name for determinism
+        return sorted(fetches, key=lambda x: x["name"])
+
+    def parse_lockfile(self, project_dir: Path, deep: bool = True) -> dict:
+        """Parse flake.lock and optionally evaluate derivation graph.
+
+        Args:
+            project_dir: Path to project directory
+            deep: If True, evaluate full derivation graph for FOD hashes (default: True)
+
+        Returns:
+            dict with:
+                - path: Path to flake.lock
+                - hash: SHA256 of flake.lock
+                - deps: list of flake inputs (always populated)
+                - fetches: list of fixed-output derivations (only if deep=True succeeds)
+                - derivation_count: total derivations evaluated (only if deep=True)
+                - evaluation_mode: "deep" or "shallow"
+        """
         lock_path = project_dir / "flake.lock"
         flake_data = json.loads(lock_path.read_text())
 
-        # Extract direct inputs from root node
+        # Extract direct inputs from root node (shallow parsing)
         nodes = flake_data.get("nodes", {})
         root = nodes.get("root", {})
         root_inputs = root.get("inputs", {})
@@ -67,11 +173,27 @@ class NixToolchain(Toolchain):
 
                 deps.append(dep)
 
-        return {
+        result = {
             "path": lock_path,
             "hash": hash_file(lock_path),
             "deps": deps,
+            "evaluation_mode": "shallow",
         }
+
+        # Deep evaluation: get full derivation graph and extract FODs
+        if deep:
+            try:
+                graph = self.evaluate_derivation_graph(project_dir)
+                fetches = self.extract_fixed_output_hashes(graph)
+                result["fetches"] = fetches
+                result["derivation_count"] = len(graph)
+                result["evaluation_mode"] = "deep"
+            except NixEvaluationError as e:
+                warnings.warn(f"Deep evaluation failed, using shallow mode: {e}")
+            except Exception as e:
+                warnings.warn(f"Unexpected error in deep evaluation, using shallow mode: {e}")
+
+        return result
 
     def verify_deps(self, deps: list[dict]) -> list[dict]:
         """Verify flake inputs against nix store."""
@@ -124,7 +246,7 @@ class NixToolchain(Toolchain):
 
             # Create build directory and copy artifacts
             project_dir = project_dir.resolve()
-            build_dir = project_dir / "build"
+            build_dir = project_dir / "kettle-build"
             build_dir.mkdir(parents=True, exist_ok=True)
 
             artifacts = []
@@ -166,7 +288,49 @@ class NixToolchain(Toolchain):
             return {"ok": False, "artifacts": [], "store_paths": [], "stdout": "", "stderr": "nix not found"}
 
     def dep_to_purl(self, dep: dict) -> dict:
-        """Convert flake input to SLSA ResourceDescriptor with PURL."""
+        """Convert dependency to SLSA ResourceDescriptor with PURL.
+
+        Handles both flake inputs (shallow mode) and fetch entries (deep mode).
+        """
+        # Check if this is a fetch entry (from deep evaluation)
+        if "outputHash" in dep:
+            return self._fetch_to_purl(dep)
+        # Otherwise it's a flake input (shallow evaluation)
+        return self._flake_input_to_purl(dep)
+
+    def _fetch_to_purl(self, fetch: dict) -> dict:
+        """Convert fixed-output derivation to PURL ResourceDescriptor."""
+        name = fetch["name"]
+        algo = fetch.get("outputHashAlgo", "sha256")
+        hash_value = fetch["outputHash"]
+
+        # PURL format: pkg:nix-fetch/{name}?hash={algo}:{hash}
+        purl = f"pkg:nix-fetch/{quote(name)}?hash={algo}:{quote(hash_value)}"
+
+        descriptor = {
+            "uri": purl,
+            "name": name,
+            "digest": {algo: hash_value},
+        }
+
+        # Add annotations for additional context
+        annotations = {}
+        if fetch.get("url"):
+            annotations["url"] = fetch["url"]
+        if fetch.get("urls"):
+            annotations["urls"] = ",".join(fetch["urls"]) if isinstance(fetch["urls"], list) else fetch["urls"]
+        if fetch.get("outputHashMode"):
+            annotations["outputHashMode"] = fetch["outputHashMode"]
+        if fetch.get("drv_path"):
+            annotations["drvPath"] = fetch["drv_path"]
+
+        if annotations:
+            descriptor["annotations"] = annotations
+
+        return descriptor
+
+    def _flake_input_to_purl(self, dep: dict) -> dict:
+        """Convert flake input to PURL ResourceDescriptor."""
         name = dep["name"]
         nar_hash = dep.get("narHash", "")
         input_type = dep.get("type", "")
@@ -196,9 +360,15 @@ class NixToolchain(Toolchain):
 
         return descriptor
 
-    def internal_params(self, info: dict, lock_hash: str) -> dict:
-        """Build SLSA internalParameters section."""
-        return {
+    def internal_params(self, info: dict, lock_hash: str, lock: dict | None = None) -> dict:
+        """Build SLSA internalParameters section.
+
+        Args:
+            info: Toolchain info from get_info()
+            lock_hash: SHA256 of lockfile
+            lock: Optional lock dict with evaluation metadata
+        """
+        params = {
             "toolchain": {
                 "nix": {
                     "version": info["nix_version"],
@@ -208,8 +378,32 @@ class NixToolchain(Toolchain):
             "lockfileHash": {"sha256": lock_hash},
         }
 
+        # Add evaluation metadata if available
+        if lock:
+            params["evaluation"] = {
+                "mode": lock.get("evaluation_mode", "shallow"),
+            }
+            if lock.get("derivation_count"):
+                params["evaluation"]["derivationCount"] = lock["derivation_count"]
+            if lock.get("fetches"):
+                params["evaluation"]["fetchCount"] = len(lock["fetches"])
+
+            # Keep flake inputs in internalParameters for human context
+            if lock.get("deps"):
+                params["flakeInputs"] = [
+                    {"name": d["name"], "narHash": d.get("narHash")}
+                    for d in lock["deps"]
+                    if d.get("narHash")
+                ]
+
+        return params
+
     def merkle_entries(self, git: dict | None, lock: dict, info: dict) -> list[bytes]:
-        """Return ordered entries for merkle tree calculation."""
+        """Return ordered entries for merkle tree calculation.
+
+        Uses fetches (FOD hashes) if available from deep evaluation,
+        otherwise falls back to flake input narHashes.
+        """
         entries = []
 
         # Git source info
@@ -224,10 +418,18 @@ class NixToolchain(Toolchain):
         # Lockfile hash
         entries.append(lock["hash"].encode())
 
-        # Flake inputs (sorted by name for determinism)
-        for dep in sorted(lock["deps"], key=lambda x: x["name"]):
-            if dep.get("narHash"):
-                entries.append(dep["narHash"].encode())
+        # Use fetches if available (deep mode), otherwise use deps (shallow mode)
+        if lock.get("fetches"):
+            # Deep mode: fixed-output derivation hashes
+            for fetch in sorted(lock["fetches"], key=lambda x: x["name"]):
+                # Format: fetch:{name}:{algo}:{hash}
+                entry = f"fetch:{fetch['name']}:{fetch['outputHashAlgo']}:{fetch['outputHash']}"
+                entries.append(entry.encode())
+        else:
+            # Shallow mode: flake input narHashes
+            for dep in sorted(lock["deps"], key=lambda x: x["name"]):
+                if dep.get("narHash"):
+                    entries.append(dep["narHash"].encode())
 
         # Toolchain info
         entries.append(info["nix_hash"].encode())
@@ -236,7 +438,11 @@ class NixToolchain(Toolchain):
         return entries
 
     def merkle_entries_labeled(self, git: dict | None, lock: dict, info: dict) -> list[tuple[str, str, bytes]]:
-        """Return labeled entries for inclusion proofs."""
+        """Return labeled entries for inclusion proofs.
+
+        Uses fetches (FOD hashes) if available from deep evaluation,
+        otherwise falls back to flake input narHashes.
+        """
         entries = []
 
         if git:
@@ -252,10 +458,19 @@ class NixToolchain(Toolchain):
 
         entries.append(("lockfile_hash", lock["hash"], lock["hash"].encode()))
 
-        for dep in sorted(lock["deps"], key=lambda x: x["name"]):
-            if dep.get("narHash"):
-                v = dep["narHash"]
-                entries.append((f"input:{dep['name']}", v, v.encode()))
+        # Use fetches if available (deep mode), otherwise use deps (shallow mode)
+        if lock.get("fetches"):
+            # Deep mode: fixed-output derivation hashes
+            for fetch in sorted(lock["fetches"], key=lambda x: x["name"]):
+                v = f"fetch:{fetch['name']}:{fetch['outputHashAlgo']}:{fetch['outputHash']}"
+                label = f"fetch:{fetch['name']}"
+                entries.append((label, v, v.encode()))
+        else:
+            # Shallow mode: flake input narHashes
+            for dep in sorted(lock["deps"], key=lambda x: x["name"]):
+                if dep.get("narHash"):
+                    v = dep["narHash"]
+                    entries.append((f"input:{dep['name']}", v, v.encode()))
 
         entries.append(("nix_hash", info["nix_hash"], info["nix_hash"].encode()))
         entries.append(("nix_version", info["nix_version"], info["nix_version"].encode()))


### PR DESCRIPTION
## Nix Deep Verification
Adds derivation graph evaluation to capture all fixed-output derivation hashes, enabling platform-agnostic dependency verification.

### Changes
- Evaluate full derivation graph via nix derivation show --recursive to extract all FOD hashes
- Deep evaluation enabled by default, gracefully falls back to shallow mode on failure
- Merkle tree now includes FOD hashes instead of flake input hashes in deep mode
- Provenance resolvedDependencies populated from FODs with new pkg:nix-fetch PURL format
- Added evaluation metadata to provenance (mode, derivation count, fetch count)
- Verification detects and uses matching evaluation mode from provenance
- Added --shallow CLI flag to skip derivation graph evaluation
- Changed build output directory to kettle-build/, cleaned before each build