### PR TITLE
Add real-world smoke tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,4 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - run: bin/kettle-build ${{ matrix.project }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,17 +38,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out repo
-        uses: actions/checkout@v6
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt, clippy
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-
       - name: Run linters
         run: ./bin/lint
 
@@ -65,18 +58,9 @@ jobs:
           - ubuntu-24.04-arm # linux-arm
 
     steps:
-      - name: Check out repo
-        uses: actions/checkout@v6
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: taiki-e/install-action@nextest
       - name: Run non-TEE tests
         shell: bash
         run: ./bin/test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,3 +64,17 @@ jobs:
       - name: Run non-TEE tests
         shell: bash
         run: ./bin/test
+
+  build-projects:
+    name: Build ${{ matrix.project }} with Kettle
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - burntsushi/ripgrep
+          - eza-community/eza
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: bin/kettle-build ${{ matrix.project }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-verbosity-flag"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394"
+dependencies = [
+ "clap",
+ "tracing-core",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,6 +1467,7 @@ dependencies = [
  "bincode 1.3.3",
  "chrono",
  "clap",
+ "clap-verbosity-flag",
  "colored",
  "der",
  "ecdsa",
@@ -1483,6 +1494,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
  "x509-cert",
 ]
@@ -1620,6 +1633,16 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1774,6 +1797,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -2674,6 +2703,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2905,6 +2943,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3123,7 +3170,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3133,6 +3192,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3285,6 +3371,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -3489,6 +3581,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3496,6 +3604,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,6 +557,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const_format"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1057,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,6 +1420,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_debug"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe266d2e243c931d8190177f20bf7f24eed45e96f39e87dc49a27b32d12d407"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,6 +1527,7 @@ dependencies = [
  "serde_json",
  "sev 7.1.0 (git+https://github.com/virtee/sev)",
  "sha2",
+ "shadow-rs",
  "signature",
  "tabled",
  "tempfile",
@@ -1522,6 +1562,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.3+1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,6 +1587,18 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1716,6 +1780,15 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2703,6 +2776,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "shadow-rs"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c798acfc78a69c7b038adde44084d8df875555b091da42c90ae46257cdcc41a"
+dependencies = [
+ "const_format",
+ "git2",
+ "is_debug",
+ "time",
+ "tzdb",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2959,7 +3045,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -3265,6 +3353,32 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "tz-rs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc6c929ffa10fb34f4a3c7e9a73620a83ef2e85e47f9ec3381b8289e6762f42"
+
+[[package]]
+name = "tzdb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d4e985b6dda743ae7fd4140c28105316ffd75bc58258ee6cc12934e3eb7a0c"
+dependencies = [
+ "iana-time-zone",
+ "tz-rs",
+ "tzdb_data",
+]
+
+[[package]]
+name = "tzdb_data"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42302a846dea7ab786f42dc5f519387069045acff793e1178d9368414168fe95"
+dependencies = [
+ "tz-rs",
+]
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "kettle"
 version = "0.1.1"
 edition = "2024"
 repository = "https://github.com/lunal-dev/kettle"
+build = "build.rs"
 
 [features]
 attest = ["attestation/attest"]
@@ -64,10 +65,14 @@ clap-verbosity-flag = { version = "3.0.4", default-features = false, features = 
     "tracing",
 ] }
 tracing-subscriber = { version = "=0.3.19", features = ["tracing"] }
+shadow-rs = { version = "1.7.1", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"
 regex-lite = "0.1"
+
+[build-dependencies]
+shadow-rs = "1.7.1"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,11 @@ uuid = { version = "1.21.0", features = ["v4"] }
 rs_merkle = "1.5.0"
 attestation = { git = "https://github.com/lunal-dev/attestation-rs", branch = "feat/new-attestation-lib", version = "0.1.0" }
 tokio = { version = "1.49.0", features = ["rt-multi-thread"] }
+tracing = "0.1.44"
+clap-verbosity-flag = { version = "3.0.4", default-features = false, features = [
+    "tracing",
+] }
+tracing-subscriber = { version = "=0.3.19", features = ["tracing"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/bin/kettle-build
+++ b/bin/kettle-build
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-REPO=$1
-if [[ -n $REPO ]]; then
+REPO="$1"
+if [[ -e "$REPO" ]]; then
    echo "USAGE: kettle-build USERNAME/REPO"
    exit 1
 fi

--- a/bin/kettle-build
+++ b/bin/kettle-build
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO=$1
+if [[ -n $REPO ]]; then
+   echo "USAGE: kettle-build USERNAME/REPO"
+   exit 1
+fi
+
+DIR="/tmp/$(basename "$REPO")"
+set +x
+
+git clone "https://github.com/$REPO" "$DIR"
+cargo run --release -- build "$DIR"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    shadow_rs::ShadowBuilder::builder().build().unwrap();
+}

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,3 @@
 [advisories]
 unmaintained = 'workspace'
-ignore = [
-    "RUSTSEC-2025-0141",
-    "RUSTSEC-2023-0071",
-]
+ignore = ["RUSTSEC-2025-0141", "RUSTSEC-2023-0071", "RUSTSEC-2025-0055"]

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -8,10 +8,11 @@ use tabled::builder::Builder;
 use tabled::settings::object::Columns;
 use tabled::settings::themes::BorderCorrection;
 use tabled::settings::{Alignment, Panel, Style};
+use tracing::info;
 
 use crate::provenance::Provenance;
 
-pub async fn verify(path: &PathBuf, verbose: bool) -> Result<()> {
+pub async fn verify(path: &PathBuf) -> Result<()> {
     let build = Build::from_dir(path)?;
 
     // Get the provenance and attestation
@@ -88,10 +89,7 @@ pub async fn verify(path: &PathBuf, verbose: bool) -> Result<()> {
         }
     }
 
-    if verbose {
-        println!("{}\n{:?}", "Attestation claims".bold(), &verification);
-        println!();
-    }
+    info!("{}\n{:?}", "Attestation claims".bold(), &verification);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ use clap::{
 };
 use colored::Colorize;
 use std::path::PathBuf;
+use tracing::{debug, error};
+use tracing_subscriber::FmtSubscriber;
 
 use kettle::commands;
 
@@ -23,8 +25,8 @@ const STYLES: Styles = Styles::styled()
 struct Args {
     #[command(subcommand)]
     command: Commands,
-    #[arg(long, help = "Enable verbose output", global = true)]
-    verbose: bool,
+    #[command(flatten)]
+    verbosity: clap_verbosity_flag::Verbosity,
 }
 
 #[derive(Subcommand, Debug)]
@@ -52,29 +54,28 @@ enum Commands {
         /// Path to directory containing provenance.json and evidence.b64
         #[arg(default_value = ".")]
         path: PathBuf,
-        #[arg(long, help = "Verbose output, including the entire attestation report")]
-        verbose: bool,
     },
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(args.verbosity)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("log configuration failed");
+
+    debug!("got args: {:?}", args);
     let result = match args.command {
         Commands::Attest { ref path } => commands::attest::attest(path).await,
         Commands::Build { ref path } => commands::build::build(path),
-        Commands::Verify { ref path, verbose } => commands::verify::verify(path, verbose).await,
+        Commands::Verify { ref path } => commands::verify::verify(path).await,
     };
 
-    if args.verbose {
-        result
-    } else {
-        if let Err(e) = result {
-            eprintln!("{}", "Error during run:".red());
-            eprintln!("  {}", e);
-            std::process::exit(1);
-        }
-
-        Ok(())
+    if let Err(e) = result {
+        error!("{}", "Error during run:".red());
+        error!("  {}", e);
     }
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use clap::{
     builder::{Styles, styling::AnsiColor},
 };
 use colored::Colorize;
-use std::path::PathBuf;
+use std::{path::PathBuf, process::exit};
 use tracing::{debug, error};
 use tracing_subscriber::FmtSubscriber;
 
@@ -75,6 +75,7 @@ async fn main() -> anyhow::Result<()> {
     if let Err(e) = result {
         error!("{}", "Error during run:".red());
         error!("  {}", e);
+        exit(1);
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ enum Commands {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() {
     let args = Args::parse();
     let subscriber = FmtSubscriber::builder()
         .with_max_level(args.verbosity)
@@ -77,6 +77,4 @@ async fn main() -> anyhow::Result<()> {
         error!("  {}", e);
         exit(1);
     }
-
-    Ok(())
 }

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -134,7 +134,7 @@ pub(crate) struct BuildDefiniton {
     pub(crate) resolved_dependencies: Vec<ResolvedDependency>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ResolvedDependency {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -237,7 +237,7 @@ pub struct ToolchainVersion {
     pub(crate) version: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Annotation {
     pub(crate) drv_path: String,

--- a/src/toolchain/cargo.rs
+++ b/src/toolchain/cargo.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result, anyhow};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use tracing::debug;
 
 use crate::{
     provenance::{Digest, InternalParameters, ResolvedDependency, Toolchain, ToolchainVersion},
@@ -41,9 +42,13 @@ impl ToolchainDriver for CargoInputs {
         lockfile_bytes: &[u8],
     ) -> Result<Self> {
         let rustc = ToolBinaryInfo::via_rustup("rustc")?;
+        debug!("rustc info {:?}", rustc);
         let cargo = ToolBinaryInfo::via_rustup("cargo")?;
-        let kettle = ToolBinaryInfo::via_which("kettle")?;
+        debug!("cargo info {:?}", rustc);
+        let kettle = ToolBinaryInfo::kettle_info()?;
+        debug!("kettle info {:?}", rustc);
         let resolved_deps = parse_cargo_lock(lockfile_bytes)?;
+        debug!("found deps {:?}", resolved_deps);
         Ok(Self {
             kettle_version: kettle.version,
             kettle_hash: kettle.sha256,

--- a/src/toolchain/cargo.rs
+++ b/src/toolchain/cargo.rs
@@ -13,6 +13,7 @@ pub(crate) fn build(path: &PathBuf) -> Result<()> {
     crate::toolchain::runner::run::<CargoInputs>(path)
 }
 
+#[derive(Debug)]
 struct CargoInputs {
     kettle_version: String,
     kettle_hash: String,

--- a/src/toolchain/driver.rs
+++ b/src/toolchain/driver.rs
@@ -6,6 +6,8 @@ use std::process::Command;
 
 use crate::provenance::{InternalParameters, ResolvedDependency};
 
+shadow_rs::shadow!(binary);
+
 // --- Moved from toolchain.rs ---
 
 #[derive(Debug)]
@@ -120,6 +122,7 @@ pub(crate) struct ProvenanceFields {
     pub(crate) resolved_dependencies: Vec<ResolvedDependency>,
 }
 
+#[derive(Debug)]
 pub(crate) struct ToolBinaryInfo {
     pub(crate) version: String,
     pub(crate) sha256: String,
@@ -163,6 +166,12 @@ impl ToolBinaryInfo {
             .output()
             .with_context(|| format!("{cmd} --version failed"))?;
         let version = String::from_utf8(ver.stdout)?.trim().to_string();
+        Ok(Self { version, sha256 })
+    }
+
+    pub(crate) fn kettle_info() -> Result<Self> {
+        let version = binary::VERSION.to_string();
+        let sha256 = binary::VERSION.to_string();
         Ok(Self { version, sha256 })
     }
 }

--- a/src/toolchain/driver.rs
+++ b/src/toolchain/driver.rs
@@ -3,6 +3,7 @@ use chrono::DateTime;
 use sha2::{Digest as _, Sha256};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use tracing::debug;
 
 use crate::provenance::{InternalParameters, ResolvedDependency};
 
@@ -158,6 +159,12 @@ impl ToolBinaryInfo {
             .arg(cmd)
             .output()
             .with_context(|| format!("which {cmd} failed"))?;
+
+        debug!("which {cmd} output: {:?}", which);
+        if which.stdout.is_empty() {
+            return Err(anyhow!("could not find command named `{}`", cmd));
+        }
+
         let bin = PathBuf::from(String::from_utf8(which.stdout)?.trim().to_string());
         let sha256 = hex::encode(Sha256::digest(fs_err::read(&bin)?));
 

--- a/src/toolchain/driver.rs
+++ b/src/toolchain/driver.rs
@@ -8,6 +8,7 @@ use crate::provenance::{InternalParameters, ResolvedDependency};
 
 // --- Moved from toolchain.rs ---
 
+#[derive(Debug)]
 pub(crate) struct BuildMetadata {
     pub(crate) invocation_id: String,
     pub(crate) started_on: String,

--- a/src/toolchain/nix.rs
+++ b/src/toolchain/nix.rs
@@ -64,7 +64,7 @@ impl ToolchainDriver for NixInputs {
         lockfile_bytes: &[u8],
     ) -> Result<Self> {
         let nix = ToolBinaryInfo::via_which("nix")?;
-        let kettle = ToolBinaryInfo::via_which("kettle")?;
+        let kettle = ToolBinaryInfo::kettle_info()?;
         let flake_deps = parse_flake_lock(lockfile_bytes)?;
         let graph = evaluate_derivation_graph(path)?;
         let derivation_count = graph.as_object().map(|o| o.len()).unwrap_or(0);

--- a/src/toolchain/runner.rs
+++ b/src/toolchain/runner.rs
@@ -2,6 +2,7 @@ use anyhow::{Result, anyhow};
 use rs_merkle::MerkleTree;
 use sha2::{Digest as _, Sha256};
 use std::path::PathBuf;
+use tracing::debug;
 
 use crate::provenance::{
     BuildDefiniton, Builder, Byproduct, Digest, ExternalParameters, Metadata, Predicate,
@@ -10,9 +11,12 @@ use crate::provenance::{
 
 use super::driver::{Artifact, BuildMetadata, GitContext, ProvenanceFields, ToolchainDriver};
 
-pub(crate) fn run<T: ToolchainDriver>(path: &PathBuf) -> Result<()> {
+pub(crate) fn run<T: ToolchainDriver + std::fmt::Debug>(path: &PathBuf) -> Result<()> {
+    debug!("input dir: {:?}", path);
+
     // 1. Clean / create output dir
     let output_dir = path.join("kettle-build");
+    debug!("output dir: {:?}", output_dir);
     if fs_err::exists(&output_dir)? {
         fs_err::remove_dir_all(&output_dir)?;
     }
@@ -20,16 +24,20 @@ pub(crate) fn run<T: ToolchainDriver>(path: &PathBuf) -> Result<()> {
 
     // 2. Git context (shared)
     let git = GitContext::from_dir(path)?;
+    debug!("git context: {:?}", git);
 
     // 3. Read and hash lockfile (shared)
     let lockfile_bytes = fs_err::read(path.join(T::lockfile_filename()))?;
     let lockfile_hash = hex::encode(Sha256::digest(&lockfile_bytes));
+    debug!("lockfile hash: {}", lockfile_hash);
 
     // 4. Toolchain-specific inputs
     let inputs = T::collect_inputs(path, &git, &lockfile_hash, &lockfile_bytes)?;
+    debug!("inputs: {:?}", inputs);
 
     // 5. Start metadata
     let mut build_metadata = BuildMetadata::start();
+    debug!("build metadata: {:?}", build_metadata);
 
     // 6. Run build
     println!("Running `{}`", T::build_command_display());

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -25,10 +25,10 @@ fn cli_build_error_unknown_project() {
         "should fail on empty dir: {:?}",
         output.status
     );
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stderr.contains("Could not determine toolchain"),
-        "stderr should mention toolchain detection failure: {stderr}"
+        stdout.contains("Could not determine toolchain"),
+        "stderr should mention toolchain detection failure: {stdout}"
     );
 }
 
@@ -94,11 +94,11 @@ fn cli_attest_feature_disabled() {
         output.status,
     );
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stderr.contains("Attestation is disabled"),
+        stdout.contains("Attestation is disabled"),
         "should say attestation is disabled, but got: {:?}",
-        stderr,
+        stdout,
     );
 }
 


### PR DESCRIPTION
Use a release mode build of Kettle to check out and build ripgrep (Cargo) and eza (nix), to make sure the build pipelines work in real life.