### PR TITLE
Add nonce support to `attest`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,11 @@ name: Test
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
   merge_group:
-    types: [checks_requested]
+    types: [ checks_requested ]
   workflow_dispatch:
 
 permissions: read-all
@@ -79,28 +79,32 @@ jobs:
           if-no-files-found: error
 
   build-projects:
-    needs: [build]
+    needs: [ build ]
     name: Build ${{ matrix.project }} with Kettle
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        project: [ripgrep, eza, openclaw]
+        project: [ ripgrep, eza, openclaw ]
         include:
           - project: ripgrep
             owner: burntsushi
             toolchain: rust
+            ref: 4519153e5e461527f4bca45b042fff45c4ec6fb9
           - project: eza
             owner: eza-community
             toolchain: nix
+            ref: eed27ed05e74542af5852aed40e3dbff87d69c43
           - project: openclaw
             owner: openclaw
             toolchain: pnpm
+            ref: d518260bb8261bb179cfb421a8c166915bb59dd1
     steps:
       - name: Check out ${{ matrix.project }}
         uses: actions/checkout@v6
         with:
           repository: "${{ matrix.owner }}/${{ matrix.project }}"
+          ref: "${{ matrix.ref }}"
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         if: ${{ matrix.toolchain == 'rust' }}
       - uses: cachix/install-nix-action@v31

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ claude.md
 # Added by cargo
 
 /target
+/kettle-build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,15 +156,14 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "0.1.0"
-source = "git+https://github.com/lunal-dev/attestation-rs?branch=feat%2Fnew-attestation-lib#c0323a12a21ac574cf40be49148b8d6b634bc0be"
+version = "0.4.0"
+source = "git+https://github.com/lunal-dev/attestation-rs?branch=main#681231fe0115104911b0a16da864e4559d95f4e4"
 dependencies = [
  "anyhow",
  "async-trait",
- "az-snp-vtpm",
- "az-tdx-vtpm",
- "base64 0.22.1",
+ "base64",
  "cfg-if",
+ "chrono",
  "der",
  "ecdsa",
  "getrandom 0.2.17",
@@ -182,16 +172,18 @@ dependencies = [
  "log",
  "p256",
  "p384",
+ "pem",
  "pem-rfc7468 1.0.0",
  "reqwest 0.12.28",
  "rsa",
  "scroll",
  "serde",
  "serde_json",
- "sev 6.3.1",
+ "sev 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2",
  "signature",
  "spki",
+ "subtle",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -229,54 +221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "az-cvm-vtpm"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de89af1208d16b05ef093680a32a6d8e4dce9146caf30ae6aa6181777907285a"
-dependencies = [
- "jsonwebkey",
- "memoffset",
- "openssl",
- "serde",
- "serde-big-array",
- "serde_json",
- "sev 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2",
- "thiserror 2.0.18",
- "tss-esapi",
- "zerocopy",
-]
-
-[[package]]
-name = "az-snp-vtpm"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3d6071c96b6306e616d98ff18b8f13de2b55f16f494094f16e22f26d985311"
-dependencies = [
- "az-cvm-vtpm",
- "clap",
- "serde",
- "sev 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.18",
- "ureq",
-]
-
-[[package]]
-name = "az-tdx-vtpm"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68381aac2d985b3482b67aa9766b0a5c97afcb7e794815871b824d7766cca56b"
-dependencies = [
- "az-cvm-vtpm",
- "base64-url",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "ureq",
- "zerocopy",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,30 +228,9 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64-url"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5b428e9fb429c6fda7316e9b006f993e6b4c33005e4659339fb5214479dddec"
-dependencies = [
- "base64 0.22.1",
-]
 
 [[package]]
 name = "base64ct"
@@ -323,32 +246,6 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
-]
-
-[[package]]
-name = "bitfield"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
 
 [[package]]
 name = "bitfield"
@@ -369,12 +266,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -520,12 +411,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codicon"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12170080f3533d6f09a19f81596f836854d0fa4867dc32c8172b8474b4e9de61"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,35 +459,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
-dependencies = [
- "cookie",
- "document-features",
- "idna",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "url",
 ]
 
 [[package]]
@@ -775,15 +631,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,26 +681,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enumflags2"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
-dependencies = [
- "enumflags2_derive",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -921,21 +748,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1068,7 +880,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "libc",
  "libgit2-sys",
  "log",
@@ -1149,12 +961,6 @@ checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
 ]
-
-[[package]]
-name = "hostname-validator"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 
 [[package]]
 name = "http"
@@ -1240,7 +1046,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1486,30 +1292,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebkey"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c57c852b14147e2bd58c14fde40398864453403ef632b1101db130282ee6e2cc"
-dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
- "generic-array",
- "num-bigint",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "yasna",
- "zeroize",
-]
-
-[[package]]
 name = "kettle"
 version = "0.1.1"
 dependencies = [
  "anyhow",
  "attestation",
- "base64 0.22.1",
- "bincode 1.3.3",
+ "base64",
+ "bincode",
  "chrono",
  "clap",
  "clap-verbosity-flag",
@@ -1525,7 +1314,7 @@ dependencies = [
  "pem",
  "pretty_assertions",
  "regex-lite",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "rs_merkle",
  "rsa",
  "serde",
@@ -1593,7 +1382,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "libc",
 ]
 
@@ -1622,12 +1411,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,16 +1421,6 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "mbox"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d142aeadbc4e8c679fc6d93fbe7efe1c021fa7d80629e615915b519e3bc6de"
-dependencies = [
- "libc",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "memchr"
@@ -1750,17 +1523,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,15 +1562,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oid"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c19903c598813dba001b53beeae59bb77ad4892c5c1b9b3500ce4293a0d06c2"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "oid-registry"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,48 +1583,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -1928,7 +1643,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
 ]
 
@@ -1955,41 +1670,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "picky-asn1"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295eea0f33c16be21e2a98b908fdd4d73c04dd48c8480991b76dbcf0cb58b212"
-dependencies = [
- "oid",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "picky-asn1-der"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df7873a9e36d42dadb393bea5e211fe83d793c172afad5fb4ec846ec582793f"
-dependencies = [
- "picky-asn1",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "picky-asn1-x509"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5f20f71a68499ff32310f418a6fad8816eac1a2859ed3f0c5c741389dd6208"
-dependencies = [
- "base64 0.21.7",
- "oid",
- "picky-asn1",
- "picky-asn1-der",
- "serde",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -2244,15 +1924,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92195228612ac8eed47adbc2ed0f04e513a4ccb98175b6f2bd04d963b533655"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,39 +1935,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-lite"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -2304,7 +1946,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "http",
@@ -2338,11 +1980,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -2451,7 +2093,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2460,9 +2102,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2524,9 +2166,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2591,7 +2233,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2723,16 +2365,14 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "6.3.1"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420c6c161b5d6883d8195584a802b114af6c884ed56d937d994e30f7f81d54ec"
+checksum = "c2ff74d7e7d1cc172f3a45adec74fbeee928d71df095b85aaaf66eb84e1e31e6"
 dependencies = [
- "base64 0.22.1",
- "bincode 2.0.1",
- "bitfield 0.19.4",
- "bitflags 2.10.0",
+ "base64",
+ "bitfield",
+ "bitflags",
  "byteorder",
- "codicon",
  "dirs",
  "hex",
  "iocuddle",
@@ -2740,9 +2380,6 @@ dependencies = [
  "libc",
  "p384",
  "rsa",
- "serde",
- "serde-big-array",
- "serde_bytes",
  "sha2",
  "static_assertions",
  "uuid",
@@ -2752,32 +2389,11 @@ dependencies = [
 [[package]]
 name = "sev"
 version = "7.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ff74d7e7d1cc172f3a45adec74fbeee928d71df095b85aaaf66eb84e1e31e6"
-dependencies = [
- "base64 0.22.1",
- "bitfield 0.19.4",
- "bitflags 2.10.0",
- "byteorder",
- "dirs",
- "hex",
- "iocuddle",
- "lazy_static",
- "libc",
- "openssl",
- "rdrand",
- "static_assertions",
- "uuid",
-]
-
-[[package]]
-name = "sev"
-version = "7.1.0"
 source = "git+https://github.com/virtee/sev#900d42d6a1f9102ed52faa3a3889b54e8a7e12c8"
 dependencies = [
- "base64 0.22.1",
- "bitfield 0.19.4",
- "bitflags 2.10.0",
+ "base64",
+ "bitfield",
+ "bitflags",
  "byteorder",
  "dirs",
  "hex",
@@ -2949,7 +2565,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2989,12 +2605,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "target-lexicon"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -3258,7 +2868,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -3347,39 +2957,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tss-esapi"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ea9ccde878b029392ac97b5be1f470173d06ea41d18ad0bb3c92794c16a0f2"
-dependencies = [
- "bitfield 0.14.0",
- "enumflags2",
- "getrandom 0.2.17",
- "hostname-validator",
- "log",
- "mbox",
- "num-derive",
- "num-traits",
- "oid",
- "picky-asn1",
- "picky-asn1-x509",
- "regex",
- "serde",
- "tss-esapi-sys",
- "zeroize",
-]
-
-[[package]]
-name = "tss-esapi-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535cd192581c2ec4d5f82e670b1d3fbba6a23ccce8c85de387642051d7cad5b5"
-dependencies = [
- "pkg-config",
- "target-lexicon",
-]
-
-[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3448,40 +3025,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
-name = "ureq"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
-dependencies = [
- "base64 0.22.1",
- "cookie_store",
- "log",
- "percent-encoding",
- "serde",
- "serde_json",
- "ureq-proto",
- "utf-8",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
-dependencies = [
- "base64 0.22.1",
- "http",
- "httparse",
- "log",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3492,12 +3035,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -3540,12 +3077,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vte"
@@ -3687,7 +3218,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4121,7 +3652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",
@@ -4191,15 +3722,6 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "yasna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
-dependencies = [
- "num-bigint",
-]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,9 +200,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -1025,15 +1025,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ thiserror = "2.0.18"
 x509-cert = { version = "0.2.5", features = ["std"] }
 uuid = { version = "1.21.0", features = ["v4"] }
 rs_merkle = "1.5.0"
-attestation = { git = "https://github.com/lunal-dev/attestation-rs", branch = "feat/new-attestation-lib", version = "0.1.0" }
+attestation = { git = "https://github.com/lunal-dev/attestation-rs", branch = "main", version = "0.4.0" }
 tokio = { version = "1.49.0", features = ["rt-multi-thread"] }
 tracing = "0.1.44"
 clap-verbosity-flag = { version = "3.0.4", default-features = false, features = [

--- a/bin/kettle
+++ b/bin/kettle
@@ -4,12 +4,18 @@ set -euo pipefail
 # Match options to rust-analyzer so we stop fighting
 export RUSTC_BOOTSTRAP=1
 
-AZURE_SECURITY_TYPE="$(curl -s -H Metadata:true 'http://169.254.169.254/metadata/instance?api-version=2023-07-01' | jq .compute.securityProfile.securityType -r)"
+if [[ "$(cat /sys/devices/virtual/dmi/id/chassis_asset_tag 2>/dev/null)" == "7783-7084-3265-9085-8269-3286-77" ]]; then
+  AZURE=true
+fi
 
-if [[ "$AZURE_SECURITY_TYPE" == "ConfidentialVM" ]]; then
-  set +x
+if [[ -n "${AZURE:-}" ]] ; then
+  AZURE_SECURITY_TYPE="$(curl -s -H Metadata:true 'http://169.254.169.254/metadata/instance?api-version=2023-07-01' | jq .compute.securityProfile.securityType -r)"
+fi
+
+if [[ "${AZURE_SECURITY_TYPE:-}" == "ConfidentialVM" ]]; then
+  set -x
   cargo run --features attest -- "$@"
 else
-  set +x
+  set -x
   cargo run -- "$@"
 fi

--- a/bin/kettle
+++ b/bin/kettle
@@ -8,8 +8,8 @@ AZURE_SECURITY_TYPE="$(curl -s -H Metadata:true 'http://169.254.169.254/metadata
 
 if [[ "$AZURE_SECURITY_TYPE" == "ConfidentialVM" ]]; then
   set +x
-  cargo run --release --features attest -- "$@"
+  cargo run --features attest -- "$@"
 else
   set +x
-  cargo run --release -- "$@"
+  cargo run -- "$@"
 fi

--- a/bin/kettle
+++ b/bin/kettle
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+# Match options to rust-analyzer so we stop fighting
+export RUSTC_BOOTSTRAP=1
+
+AZURE_SECURITY_TYPE="$(curl -s -H Metadata:true 'http://169.254.169.254/metadata/instance?api-version=2023-07-01' | jq .compute.securityProfile.securityType -r)"
+
+if [[ "$AZURE_SECURITY_TYPE" == "ConfidentialVM" ]]; then
+  set +x
+  cargo run --release --features attest -- "$@"
+else
+  set +x
+  cargo run --release -- "$@"
+fi

--- a/bin/kettle-build
+++ b/bin/kettle-build
@@ -13,4 +13,4 @@ set +x
 if [[ ! -d "$DIR" ]]; then
    git clone --depth=1 "https://github.com/$REPO" "$DIR"
 fi
-cargo run --release -- build "$DIR"
+bin/kettle build "$DIR"

--- a/bin/test
+++ b/bin/test
@@ -1,13 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
-AZURE_SECURITY_TYPE="$(curl -s -H Metadata:true 'http://169.254.169.254/metadata/instance?api-version=2023-07-01' | jq .compute.securityProfile.securityType -r)"
+if [[ "$(cat /sys/devices/virtual/dmi/id/chassis_asset_tag 2>/dev/null)" == "7783-7084-3265-9085-8269-3286-77" ]]; then
+  AZURE=true
+fi
+
+if [[ -n "${AZURE:-}" ]] ; then
+  AZURE_SECURITY_TYPE="$(curl -s -H Metadata:true 'http://169.254.169.254/metadata/instance?api-version=2023-07-01' | jq .compute.securityProfile.securityType -r)"
+fi
 
 set -x
-
 cargo nextest run "${@:---no-fail-fast}"
+set +x
 
-if [[ "$AZURE_SECURITY_TYPE" == "ConfidentialVM" ]]; then
+if [[ "${AZURE_SECURITY_TYPE:-}" == "ConfidentialVM" ]]; then
+  set -x
   cargo nextest run --features attest "${@:---no-fail-fast}"
 else
   echo "no attestation hardware found, skipping TEE tests"

--- a/bin/test
+++ b/bin/test
@@ -1,11 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
+AZURE_SECURITY_TYPE="$(curl -s -H Metadata:true 'http://169.254.169.254/metadata/instance?api-version=2023-07-01' | jq .compute.securityProfile.securityType -r)"
+
 set -x
 
 cargo nextest run "${@:---no-fail-fast}"
 
-if dmesg 2>/dev/null | grep -i -E "snp|tdx|sev"; then
+if [[ "$AZURE_SECURITY_TYPE" == "ConfidentialVM" ]]; then
   cargo nextest run --features attest "${@:---no-fail-fast}"
 else
   echo "no attestation hardware found, skipping TEE tests"

--- a/src/commands/attest.rs
+++ b/src/commands/attest.rs
@@ -49,7 +49,7 @@ pub async fn attest(args: AttestArgs) -> Result<()> {
     };
 
     tracing::debug!("attesting with report_data {}", hex::encode(report_data));
-    let evidence_json = attestation::attest(platform, report_data.as_slice())
+    let evidence_json = attestation::attest(platform, report_data.as_slice(), &Default::default())
         .await
         .expect("attestation failed");
     fs_err::write(path.join("kettle-build/evidence.json"), evidence_json)?;

--- a/src/commands/attest.rs
+++ b/src/commands/attest.rs
@@ -1,8 +1,16 @@
 use anyhow::Result;
 use std::path::PathBuf;
 
+#[derive(clap::Args, Debug)]
+pub struct AttestArgs {
+    /// Path to the project to be built and attested
+    #[arg()]
+    path: PathBuf,
+}
+
 #[cfg(all(feature = "attest", target_os = "linux"))]
-pub async fn attest(path: &PathBuf) -> Result<()> {
+pub async fn attest(args: AttestArgs) -> Result<()> {
+    let path = &args.path;
     use crate::provenance::Provenance;
 
     // Build the thing from scratch before we attest it
@@ -30,7 +38,7 @@ pub async fn attest(path: &PathBuf) -> Result<()> {
 }
 
 #[cfg(not(all(feature = "attest", target_os = "linux")))]
-pub async fn attest(_path: &PathBuf) -> Result<()> {
+pub async fn attest(_args: AttestArgs) -> Result<()> {
     use anyhow::anyhow;
     Err(anyhow!(
         "Attestation is disabled. Rebuild Kettle with `--features attest` to enable this command."

--- a/src/commands/attest.rs
+++ b/src/commands/attest.rs
@@ -26,8 +26,11 @@ pub async fn attest(args: AttestArgs) -> Result<()> {
         "Attesting build provenance.json with checksum {}",
         hex::encode(&provenance_checksum)
     );
+    // always put the provenance checksum in the first 32 bytes
+    let mut report_data = [0u8; 48];
+    report_data[..32].copy_from_slice(&provenance_checksum);
 
-    let evidence_json = attestation::attest(platform, provenance_checksum.as_slice())
+    let evidence_json = attestation::attest(platform, report_data.as_slice())
         .await
         .expect("attestation failed");
     fs_err::write(path.join("kettle-build/evidence.json"), evidence_json)?;

--- a/src/commands/attest.rs
+++ b/src/commands/attest.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use anyhow::anyhow;
 use std::path::PathBuf;
 
 #[derive(clap::Args, Debug)]
@@ -6,11 +7,16 @@ pub struct AttestArgs {
     /// Path to the project to be built and attested
     #[arg()]
     path: PathBuf,
+    /// Optional nonce, as hex string, to be included in the attestation.
+    /// Can be up to 16 bytes. For a unique nonce, use e.g. `uuidgen`.
+    #[arg(short, long)]
+    nonce: Option<String>,
 }
 
 #[cfg(all(feature = "attest", target_os = "linux"))]
 pub async fn attest(args: AttestArgs) -> Result<()> {
     let path = &args.path;
+    let nonce = args.nonce;
     use crate::provenance::Provenance;
 
     // Build the thing from scratch before we attest it
@@ -30,6 +36,19 @@ pub async fn attest(args: AttestArgs) -> Result<()> {
     let mut report_data = [0u8; 48];
     report_data[..32].copy_from_slice(&provenance_checksum);
 
+    // if there is a nonce, put it in the last 16 bytes
+    if let Some(nonce_string) = nonce {
+        let nonce_data = hex::decode(nonce_string.replace("-", ""))?;
+        if nonce_data.len() > 16 {
+            return Err(anyhow!(
+                "Nonce {} is too long! Must be 16 bytes (32 chars of hex) or less.",
+                nonce_string
+            ));
+        }
+        report_data[32..(32 + nonce_data.len())].copy_from_slice(&nonce_data);
+    };
+
+    tracing::debug!("attesting with report_data {}", hex::encode(report_data));
     let evidence_json = attestation::attest(platform, report_data.as_slice())
         .await
         .expect("attestation failed");
@@ -42,7 +61,6 @@ pub async fn attest(args: AttestArgs) -> Result<()> {
 
 #[cfg(not(all(feature = "attest", target_os = "linux")))]
 pub async fn attest(_args: AttestArgs) -> Result<()> {
-    use anyhow::anyhow;
     Err(anyhow!(
         "Attestation is disabled. Rebuild Kettle with `--features attest` to enable this command."
     ))

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -209,11 +209,14 @@ mod tests {
                     tee: 0,
                     snp: 0,
                     microcode: 0,
+                    fmc: Some(0),
                 },
                 platform_data: Default::default(),
             },
             report_data_match: None,
             init_data_match: None,
+            collateral_verified: true,
+            tcb_status: None,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,27 +31,17 @@ struct Args {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
-    /// Build and attest a project inside a Trusted Execution Environment
-    #[cfg(all(feature = "attest", target_os = "linux"))]
-    Attest {
-        #[arg()]
-        path: PathBuf,
-    },
-    #[cfg(not(all(feature = "attest", target_os = "linux")))]
-    #[command(hide = true)]
-    Attest {
-        #[arg(default_value = ".")]
-        path: PathBuf,
-    },
+    /// Build and attest a project inside a Trusted Execution Environment.
+    Attest(commands::attest::AttestArgs),
     /// Build a project with SLSA v1.2 provenance
     Build {
-        /// Path to the Cargo or Nix project
+        /// Path to the project to be built
         #[arg()]
         path: PathBuf,
     },
     /// Verify a Kettle build, including provenance and attestation
     Verify {
-        /// Path to directory containing provenance.json and evidence.b64
+        /// Path to directory containing provenance.json and evidence.json
         #[arg(default_value = ".")]
         path: PathBuf,
     },
@@ -67,7 +57,7 @@ async fn main() {
 
     debug!("got args: {:?}", args);
     let result = match args.command {
-        Commands::Attest { ref path } => commands::attest::attest(path).await,
+        Commands::Attest(args) => commands::attest::attest(args).await,
         Commands::Build { ref path } => commands::build::build(path),
         Commands::Verify { ref path } => commands::verify::verify(path).await,
     };


### PR DESCRIPTION
Adds a new option to the `attest` subcommand, accepting up to 16 bytes that will be appended to the provenance.json checksum and included in the attestation report data. Less than 16 bytes is zero padded, more than 16 bytes is rejected as too long.