### PR TITLE
Adding Harden Runner to monitor networking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,10 @@ jobs:
             toolchain: pnpm
             ref: d518260bb8261bb179cfb421a8c166915bb59dd1
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - name: Check out ${{ matrix.project }}
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
The goal of the Harden Runner is to monitor networking, which should allow us to detect malicious payloads or supply chain attacks that are calling a remote C&C server, as long as they are attempting to run in CI, which isn't a given.