### PR TITLE
Release reproducible Kettle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,10 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+    permissions:
+      "attestations": "write"
+      "contents": "read"
+      "id-token": "write"
     steps:
       - name: enable windows longpaths
         run: |
@@ -144,6 +148,10 @@ jobs:
           # Actually do builds and make zips and whatnot
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
+      - name: Attest
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}*"
       - id: cargo-dist
         name: Post-build
         # We force bash here just because github makes it really hard to get values up

--- a/bin/reproduce-build
+++ b/bin/reproduce-build
@@ -14,3 +14,11 @@ docker build . -t kettle-reproducible \
   --build-arg "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH" \
   --target=artifact \
   --output "type=local,dest=$(pwd)/target/reproducible/"
+
+# Package the binary for dist to release
+(
+    cd target/reproducible
+    tar cfvj kettle-reproducible-x86_64-unknown-linux-gnu.tar.xz kettle
+    sha256sum -b kettle-reproducible-x86_64-unknown-linux-gnu.tar.xz > \
+      kettle-reproducible-x86_64-unknown-linux-gnu.tar.xz.sha256
+)

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -15,6 +15,8 @@ targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-da
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
+# Whether to publish GitHub attestations for builds
+github-attestations = true
 
 [dist.github-action-commits]
 "actions/checkout" = "de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -22,3 +22,7 @@ github-attestations = true
 "actions/checkout" = "de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
 "actions/upload-artifact" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1"
 "actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1"
+
+[[dist.extra-artifacts]]
+artifacts = ["target/reproducible/kettle"]
+build = ["bin/reproduce-build"]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -24,5 +24,8 @@ github-attestations = true
 "actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1"
 
 [[dist.extra-artifacts]]
-artifacts = ["target/reproducible/kettle"]
+artifacts = [
+    "target/reproducible/kettle-reproducible-x86_64-unknown-linux-gnu.tar.xz",
+    "target/reproducible/kettle-reproducible-x86_64-unknown-linux-gnu.tar.xz.sha256"
+]
 build = ["bin/reproduce-build"]


### PR DESCRIPTION
Adds an additional artifact to the release process: `kettle` built using StageX docker images, fully reproducibly.