### PR TITLE
Verify artifacts from provenance subjects

### DIFF
--- a/regenerated.json
+++ b/regenerated.json
@@ -1,0 +1,93 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "predicate": {
+    "buildDefinition": {
+      "buildType": "https://lunal.dev/kettle/pnpm@v1",
+      "externalParameters": {
+        "buildCommand": "pnpm build",
+        "source": {
+          "digest": {
+            "gitCommit": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+            "gitTree": "f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5"
+          },
+          "uri": "https://github.com/example/openclaw.git"
+        }
+      },
+      "internalParameters": {
+        "lockfileHash": {
+          "sha256": "c0ffee00deadbeef1234567890abcdef1234567890abcdef1234567890abcdef"
+        },
+        "toolchain": {
+          "pnpm": {
+            "digest": {
+              "sha256": "def456def456def456def456def456def456def456def456def456def456def4"
+            },
+            "version": "8.15.4"
+          },
+          "node": {
+            "digest": {
+              "sha256": "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1"
+            },
+            "version": "v18.12.0"
+          },
+          "kettle": {
+            "digest": {
+              "sha256": "be54407b39e0d0680fafbc0f6eeac1cc0b91292589e1284ae307f950652bccad"
+            },
+            "version": "kettle 0.1.0"
+          }
+        }
+      },
+      "resolvedDependencies": [
+        {
+          "digest": {
+            "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          },
+          "name": "@types/node",
+          "uri": "pkg:npm/%40types/node@20.11.5"
+        },
+        {
+          "digest": {
+            "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "name": "semver",
+          "uri": "pkg:npm/semver@7.6.0"
+        },
+        {
+          "digest": {
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+          },
+          "name": "typescript",
+          "uri": "pkg:npm/typescript@5.4.3"
+        }
+      ]
+    },
+    "runDetails": {
+      "builder": {
+        "id": "https://lunal.dev/kettle-tee/v1"
+      },
+      "byproducts": [
+        {
+          "digest": {
+            "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+          },
+          "name": "input_merkle_root"
+        }
+      ],
+      "metadata": {
+        "invocationId": "build-20260316-120000-openclaw1",
+        "startedOn": "2026-03-16T12:00:00.000000+00:00",
+        "finishedOn": "2026-03-16T12:01:00.000000+00:00"
+      }
+    }
+  },
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "subject": [
+    {
+      "digest": {
+        "sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      },
+      "name": "dist.tar.gz"
+    }
+  ]
+}

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -205,6 +205,7 @@ fn verify_provenance(
 struct Build {
     provenance_bytes: Vec<u8>,
     evidence_bytes: Vec<u8>,
+    top_level: Vec<DirEntry>,
     artifacts: Vec<DirEntry>,
 }
 
@@ -213,17 +214,33 @@ impl Build {
         let project_dir = fs_err::canonicalize(path)?;
         let evidence_bytes = fs_err::read(project_dir.join("evidence.json"))?;
         let provenance_bytes = fs_err::read(project_dir.join("provenance.json"))?;
-        let artifacts = fs_err::read_dir(project_dir.join("artifacts"))?
+
+        // Regular files sitting directly in the build dir — e.g. a binary
+        // published by `oras` alongside provenance.json. Subdirectories such as
+        // `artifacts/` are not regular files and are excluded here.
+        let top_level = fs_err::read_dir(&project_dir)?
             .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
             .collect();
 
-        let build = Build {
-            provenance_bytes,
-            evidence_bytes,
-            artifacts,
+        // `artifacts/` is optional: classic builds use it, oras-published
+        // builds may not have it at all. Its absence is not an error.
+        let artifacts_dir = project_dir.join("artifacts");
+        let artifacts = if artifacts_dir.is_dir() {
+            fs_err::read_dir(artifacts_dir)?
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+                .collect()
+        } else {
+            vec![]
         };
 
-        Ok(build)
+        Ok(Build {
+            provenance_bytes,
+            evidence_bytes,
+            top_level,
+            artifacts,
+        })
     }
 }
 
@@ -460,6 +477,27 @@ mod tests {
         assert!(!build.provenance_bytes.is_empty());
         assert!(!build.evidence_bytes.is_empty());
         assert_eq!(build.artifacts.len(), 1);
+        // top_level holds the two regular files in the root; the artifacts/
+        // subdirectory is not a regular file and is excluded.
+        assert_eq!(build.top_level.len(), 2);
+    }
+
+    #[test]
+    fn build_from_dir_collects_top_level_binary() {
+        let tmp = TempDir::new().unwrap();
+        fs_err::write(tmp.path().join("evidence.json"), b"{}").unwrap();
+        fs_err::write(tmp.path().join("provenance.json"), CARGO_FIXTURE).unwrap();
+        // oras-style: binary dropped directly beside provenance.json, no artifacts/
+        fs_err::write(tmp.path().join("rg"), b"binary").unwrap();
+
+        let build = Build::from_dir(&tmp.path().to_path_buf()).unwrap();
+        let names: Vec<String> = build
+            .top_level
+            .iter()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert!(names.contains(&"rg".to_string()), "top_level: {names:?}");
+        assert!(build.artifacts.is_empty());
     }
 
     #[test]
@@ -479,11 +517,14 @@ mod tests {
     }
 
     #[test]
-    fn build_from_dir_missing_artifacts() {
+    fn build_from_dir_missing_artifacts_is_ok() {
+        // artifacts/ is optional now: absence is not an error.
         let tmp = TempDir::new().unwrap();
         fs_err::write(tmp.path().join("evidence.json"), b"{}").unwrap();
         fs_err::write(tmp.path().join("provenance.json"), CARGO_FIXTURE).unwrap();
-        assert!(Build::from_dir(&tmp.path().to_path_buf()).is_err());
+
+        let build = Build::from_dir(&tmp.path().to_path_buf()).unwrap();
+        assert!(build.artifacts.is_empty());
     }
 
     #[test]

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -36,7 +36,8 @@ pub async fn verify(args: VerifyArgs) -> Result<()> {
     results.push(verify_signature(&verification));
     results.push(provenance.verify_predicate());
     results.push(verify_provenance(&verification, &provenance));
-    results.extend(provenance.verify_artifacts(&build.artifacts)?);
+    let artifact_report = provenance.verify_artifacts(&build.top_level, &build.artifacts)?;
+    results.extend(artifact_report.results);
     if let Some(nonce) = nonce {
         results.push(verify_nonce(&verification, nonce));
     }
@@ -94,6 +95,11 @@ pub async fn verify(args: VerifyArgs) -> Result<()> {
     let headers = vec![format!("{}", "Verification Results".bold())];
     let footers = vec![];
     print_table(headers, rows, footers);
+
+    // Warnings are informational and do not affect the PASSED/FAILED verdict.
+    for warning in &artifact_report.warnings {
+        eprintln!("{}", format!("⚠️  {warning}").yellow());
+    }
 
     // Print detailed information about failures (if any)
     for r in results {

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -71,40 +71,90 @@ impl Provenance {
         }
     }
 
-    pub fn verify_artifacts(&self, artifacts: &[DirEntry]) -> Result<Vec<Verification>> {
-        artifacts
-            .iter()
-            .map(|entry| {
-                let name = entry.file_name().to_string_lossy().into_owned();
-                let checksum = Sha256::digest(fs_err::read(entry.path())?);
-                let subject = self.subject.iter().find(|s| s.name == name);
-                if let Some(subject) = subject {
-                    if hex::encode(checksum) == subject.digest.value() {
-                        Ok(Verification::success(&format!(
-                            "Checksum match for binary `{}`",
-                            name
-                        )))
-                    } else {
-                        Ok(Verification::failure(
-                            "Checksum mismatch for `{}`!",
-                            &format!(
-                                "Provenance did not contain checksum for binary named {:?}",
-                                name
-                            ),
-                        ))
-                    }
-                } else {
-                    Ok(Verification::failure(
-                        &format!("Checksum missing for `{}`!", name),
-                        &format!(
-                            "Provenance did not contain checksum for binary named {:?}",
-                            name
-                        ),
-                    ))
-                }
-            })
-            .collect()
+    pub fn verify_artifacts(
+        &self,
+        top_level: &[DirEntry],
+        artifacts: &[DirEntry],
+    ) -> Result<ArtifactReport> {
+        let mut results = Vec::new();
+        let mut warnings = Vec::new();
+
+        for subject in &self.subject {
+            let mut found = false;
+
+            // A subject's binary may live beside provenance.json, in artifacts/,
+            // or both. Verify and report every copy separately.
+            for entry in top_level
+                .iter()
+                .filter(|e| e.file_name().to_string_lossy() == subject.name)
+            {
+                found = true;
+                results.push(self.check_artifact(subject, entry, &subject.name)?);
+            }
+            for entry in artifacts
+                .iter()
+                .filter(|e| e.file_name().to_string_lossy() == subject.name)
+            {
+                found = true;
+                let display = format!("artifacts/{}", subject.name);
+                results.push(self.check_artifact(subject, entry, &display)?);
+            }
+
+            if !found {
+                results.push(Verification::failure(
+                    &format!("Artifact missing for `{}`!", subject.name),
+                    &format!(
+                        "Provenance lists `{}` as a subject but no matching file was found in the build directory or artifacts/",
+                        subject.name
+                    ),
+                ));
+            }
+        }
+
+        // Files in artifacts/ that provenance does not list are surfaced as
+        // warnings, not failures. Unlisted files in the build-dir root (e.g.
+        // provenance.json, evidence.json) are ignored silently.
+        for entry in artifacts {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if !self.subject.iter().any(|s| s.name == name) {
+                warnings.push(format!("artifacts/{name} is not listed in provenance.json"));
+            }
+        }
+
+        Ok(ArtifactReport { results, warnings })
     }
+
+    /// Hash `entry` and compare it to the subject's recorded digest. `display`
+    /// is the name shown in the result message (bare for root files,
+    /// `artifacts/<name>` for files under artifacts/).
+    fn check_artifact(
+        &self,
+        subject: &Subject,
+        entry: &DirEntry,
+        display: &str,
+    ) -> Result<Verification> {
+        // Subjects are assumed to record sha256 digests; a sha512 subject would
+        // compare a sha256 hex string against a sha512 one and always mismatch.
+        let checksum = hex::encode(Sha256::digest(fs_err::read(entry.path())?));
+        let expected = subject.digest.value();
+        if checksum == expected {
+            Ok(Verification::success(&format!(
+                "Checksum match for binary `{display}`"
+            )))
+        } else {
+            Ok(Verification::failure(
+                &format!("Checksum mismatch for `{display}`!"),
+                &format!("Expected checksum {expected}\nActual checksum   {checksum}"),
+            ))
+        }
+    }
+}
+
+/// Outcome of verifying the artifacts a build claims. `results` drive the
+/// PASSED/FAILED verdict; `warnings` are informational and never fail the run.
+pub struct ArtifactReport {
+    pub results: Vec<Verification>,
+    pub warnings: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -531,380 +581,198 @@ mod tests {
         fs_err::write(dir.join(name), content).unwrap();
     }
 
+    /// Collect a directory's entries as a Vec<DirEntry>, like Build::from_dir.
+    fn entries(dir: &std::path::Path) -> Vec<fs_err::DirEntry> {
+        fs_err::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect()
+    }
+
+    /// A valid Provenance (parsed from the real cargo fixture) with its subject
+    /// list swapped for the given one — far less noise than rebuilding the
+    /// whole struct in every test.
+    fn provenance_with_subjects(subjects: Vec<Subject>) -> Provenance {
+        let mut p = Provenance::from_json(CARGO_FIXTURE).unwrap();
+        p.subject = subjects;
+        p
+    }
+
+    /// A subject whose sha256 digest matches `content`.
+    fn sha256_subject(name: &str, content: &[u8]) -> Subject {
+        Subject {
+            name: name.to_string(),
+            digest: Digest::Sha256 {
+                sha256: hex::encode(Sha256::digest(content)),
+            },
+        }
+    }
+
     #[test]
-    fn verify_artifacts_checksum_match() {
+    fn verify_artifacts_subject_at_root() {
         let tmp = TempDir::new().unwrap();
         let content = b"hello binary";
-        let checksum = hex::encode(Sha256::digest(content));
         write_file_to_dir(tmp.path(), "rg", content);
 
-        let p = Provenance {
-            _type: String::new(),
-            predicate_type: String::new(),
-            predicate: Predicate {
-                build_definition: BuildDefiniton {
-                    build_type: String::new(),
-                    external_parameters: ExternalParameters {
-                        build_command: String::new(),
-                        source: Source {
-                            digest: SourceDigest {
-                                git_commit: String::new(),
-                                git_tree: String::new(),
-                            },
-                            uri: String::new(),
-                        },
-                    },
-                    internal_parameters: InternalParameters {
-                        evaluation: None,
-                        flake_inputs: None,
-                        lockfile_hash: Digest::Sha256 {
-                            sha256: String::new(),
-                        },
-                        toolchain: Toolchain::RustToolchain {
-                            rustc: ToolchainVersion {
-                                version: String::new(),
-                                digest: Digest::Sha256 {
-                                    sha256: String::new(),
-                                },
-                            },
-                            cargo: ToolchainVersion {
-                                version: String::new(),
-                                digest: Digest::Sha256 {
-                                    sha256: String::new(),
-                                },
-                            },
-                            kettle: ToolchainVersion {
-                                version: String::new(),
-                                digest: Digest::Sha256 {
-                                    sha256: String::new(),
-                                },
-                            },
-                        },
-                    },
-                    resolved_dependencies: vec![],
-                },
-                run_details: RunDetails {
-                    builder: Builder { id: String::new() },
-                    byproducts: vec![],
-                    metadata: Metadata {
-                        invocation_id: String::new(),
-                        started_on: String::new(),
-                        finished_on: None,
-                    },
-                },
-            },
-            subject: vec![Subject {
-                name: "rg".to_string(),
-                digest: Digest::Sha256 { sha256: checksum },
-            }],
-        };
+        let p = provenance_with_subjects(vec![sha256_subject("rg", content)]);
+        let report = p.verify_artifacts(&entries(tmp.path()), &[]).unwrap();
 
-        let entries: Vec<fs_err::DirEntry> = fs_err::read_dir(tmp.path())
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .collect();
-        let results = p.verify_artifacts(&entries).unwrap();
-        assert_eq!(results.len(), 1);
-        match &results[0] {
+        assert_eq!(report.results.len(), 1);
+        match &report.results[0] {
+            Verification::Success { message } => assert!(message.contains("rg")),
+            Verification::Failure { message, .. } => panic!("expected success: {message}"),
+        }
+        assert!(report.warnings.is_empty());
+    }
+
+    #[test]
+    fn verify_artifacts_subject_in_artifacts_dir() {
+        let tmp = TempDir::new().unwrap();
+        let content = b"hello binary";
+        write_file_to_dir(tmp.path(), "rg", content);
+
+        let p = provenance_with_subjects(vec![sha256_subject("rg", content)]);
+        let report = p.verify_artifacts(&[], &entries(tmp.path())).unwrap();
+
+        assert_eq!(report.results.len(), 1);
+        match &report.results[0] {
             Verification::Success { message } => {
-                assert!(message.contains("rg"));
+                assert!(message.contains("artifacts/rg"), "message: {message}");
             }
-            Verification::Failure { message, .. } => panic!("expected success, got: {message}"),
+            Verification::Failure { message, .. } => panic!("expected success: {message}"),
         }
     }
 
     #[test]
-    fn verify_artifacts_checksum_mismatch() {
+    fn verify_artifacts_subject_in_both_locations_reports_each() {
+        let root = TempDir::new().unwrap();
+        let arts = TempDir::new().unwrap();
+        let content = b"hello binary";
+        write_file_to_dir(root.path(), "rg", content);
+        write_file_to_dir(arts.path(), "rg", content);
+
+        let p = provenance_with_subjects(vec![sha256_subject("rg", content)]);
+        let report = p
+            .verify_artifacts(&entries(root.path()), &entries(arts.path()))
+            .unwrap();
+
+        assert_eq!(report.results.len(), 2);
+        assert!(
+            report
+                .results
+                .iter()
+                .all(|r| matches!(r, Verification::Success { .. })),
+            "both copies should verify"
+        );
+    }
+
+    #[test]
+    fn verify_artifacts_checksum_mismatch_shows_expected_and_actual() {
         let tmp = TempDir::new().unwrap();
-        write_file_to_dir(tmp.path(), "rg", b"hello binary");
+        write_file_to_dir(tmp.path(), "rg", b"actual contents");
 
-        let p = Provenance {
-            _type: String::new(),
-            predicate_type: String::new(),
-            predicate: Predicate {
-                build_definition: BuildDefiniton {
-                    build_type: String::new(),
-                    external_parameters: ExternalParameters {
-                        build_command: String::new(),
-                        source: Source {
-                            digest: SourceDigest {
-                                git_commit: String::new(),
-                                git_tree: String::new(),
-                            },
-                            uri: String::new(),
-                        },
-                    },
-                    internal_parameters: InternalParameters {
-                        evaluation: None,
-                        flake_inputs: None,
-                        lockfile_hash: Digest::Sha256 {
-                            sha256: String::new(),
-                        },
-                        toolchain: Toolchain::RustToolchain {
-                            rustc: ToolchainVersion {
-                                version: String::new(),
-                                digest: Digest::Sha256 {
-                                    sha256: String::new(),
-                                },
-                            },
-                            cargo: ToolchainVersion {
-                                version: String::new(),
-                                digest: Digest::Sha256 {
-                                    sha256: String::new(),
-                                },
-                            },
-                            kettle: ToolchainVersion {
-                                version: String::new(),
-                                digest: Digest::Sha256 {
-                                    sha256: String::new(),
-                                },
-                            },
-                        },
-                    },
-                    resolved_dependencies: vec![],
-                },
-                run_details: RunDetails {
-                    builder: Builder { id: String::new() },
-                    byproducts: vec![],
-                    metadata: Metadata {
-                        invocation_id: String::new(),
-                        started_on: String::new(),
-                        finished_on: None,
-                    },
-                },
-            },
-            subject: vec![Subject {
-                name: "rg".to_string(),
-                digest: Digest::Sha256 {
-                    sha256: "0000000000000000000000000000000000000000000000000000000000000000"
-                        .to_string(),
-                },
-            }],
-        };
+        let p = provenance_with_subjects(vec![sha256_subject("rg", b"different contents")]);
+        let report = p.verify_artifacts(&entries(tmp.path()), &[]).unwrap();
 
-        let entries: Vec<fs_err::DirEntry> = fs_err::read_dir(tmp.path())
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .collect();
-        let results = p.verify_artifacts(&entries).unwrap();
-        assert_eq!(results.len(), 1);
-        match &results[0] {
-            Verification::Failure { .. } => {}
+        assert_eq!(report.results.len(), 1);
+        match &report.results[0] {
+            Verification::Failure { message, details } => {
+                assert!(message.contains("mismatch"), "message: {message}");
+                let expected = hex::encode(Sha256::digest(b"different contents"));
+                let actual = hex::encode(Sha256::digest(b"actual contents"));
+                assert!(
+                    details.contains(&expected) && details.contains(&actual),
+                    "details should show both checksums: {details}"
+                );
+            }
             Verification::Success { .. } => panic!("expected failure"),
         }
     }
 
     #[test]
-    fn verify_artifacts_missing_from_subjects() {
+    fn verify_artifacts_mismatch_in_artifacts_dir_shows_prefixed_name() {
         let tmp = TempDir::new().unwrap();
-        write_file_to_dir(tmp.path(), "unknown-binary", b"data");
+        write_file_to_dir(tmp.path(), "rg", b"actual contents");
 
-        let p = Provenance {
-            _type: String::new(),
-            predicate_type: String::new(),
-            predicate: Predicate {
-                build_definition: BuildDefiniton {
-                    build_type: String::new(),
-                    external_parameters: ExternalParameters {
-                        build_command: String::new(),
-                        source: Source {
-                            digest: SourceDigest {
-                                git_commit: String::new(),
-                                git_tree: String::new(),
-                            },
-                            uri: String::new(),
-                        },
-                    },
-                    internal_parameters: InternalParameters {
-                        evaluation: None,
-                        flake_inputs: None,
-                        lockfile_hash: Digest::Sha256 {
-                            sha256: String::new(),
-                        },
-                        toolchain: Toolchain::RustToolchain {
-                            rustc: ToolchainVersion {
-                                version: String::new(),
-                                digest: Digest::Sha256 {
-                                    sha256: String::new(),
-                                },
-                            },
-                            cargo: ToolchainVersion {
-                                version: String::new(),
-                                digest: Digest::Sha256 {
-                                    sha256: String::new(),
-                                },
-                            },
-                            kettle: ToolchainVersion {
-                                version: String::new(),
-                                digest: Digest::Sha256 {
-                                    sha256: String::new(),
-                                },
-                            },
-                        },
-                    },
-                    resolved_dependencies: vec![],
-                },
-                run_details: RunDetails {
-                    builder: Builder { id: String::new() },
-                    byproducts: vec![],
-                    metadata: Metadata {
-                        invocation_id: String::new(),
-                        started_on: String::new(),
-                        finished_on: None,
-                    },
-                },
-            },
-            subject: vec![], // No subjects
-        };
+        let p = provenance_with_subjects(vec![sha256_subject("rg", b"different contents")]);
+        let report = p.verify_artifacts(&[], &entries(tmp.path())).unwrap();
 
-        let entries: Vec<fs_err::DirEntry> = fs_err::read_dir(tmp.path())
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .collect();
-        let results = p.verify_artifacts(&entries).unwrap();
-        assert_eq!(results.len(), 1);
-        match &results[0] {
+        assert_eq!(report.results.len(), 1);
+        match &report.results[0] {
             Verification::Failure { message, .. } => {
-                assert!(message.contains("Checksum missing"));
+                assert!(
+                    message.contains("artifacts/rg"),
+                    "mismatch message should carry the artifacts/ prefix: {message}"
+                );
             }
             Verification::Success { .. } => panic!("expected failure"),
         }
     }
 
     #[test]
-    fn verify_artifacts_empty_slice() {
-        let p = Provenance::from_json(CARGO_FIXTURE).unwrap();
-        let results = p.verify_artifacts(&[]).unwrap();
-        assert!(results.is_empty());
+    fn verify_artifacts_subject_missing_from_disk_fails() {
+        let p = provenance_with_subjects(vec![sha256_subject("rg", b"x")]);
+        let report = p.verify_artifacts(&[], &[]).unwrap();
+
+        assert_eq!(report.results.len(), 1);
+        match &report.results[0] {
+            Verification::Failure { message, .. } => {
+                assert!(message.contains("missing"), "message: {message}");
+            }
+            Verification::Success { .. } => panic!("expected failure"),
+        }
     }
 
     #[test]
-    fn verify_artifacts_multiple() {
+    fn verify_artifacts_unlisted_file_in_artifacts_warns_without_failing() {
         let tmp = TempDir::new().unwrap();
-        let content_a = b"binary a";
-        let checksum_a = hex::encode(Sha256::digest(content_a));
-        let content_b = b"binary b";
-        write_file_to_dir(tmp.path(), "a", content_a);
-        write_file_to_dir(tmp.path(), "b", content_b);
-        write_file_to_dir(tmp.path(), "c", b"binary c");
+        write_file_to_dir(tmp.path(), "stray", b"data");
 
-        let p = Provenance {
-            _type: String::new(),
-            predicate_type: String::new(),
-            predicate: Predicate {
-                build_definition: BuildDefiniton {
-                    build_type: String::new(),
-                    external_parameters: ExternalParameters {
-                        build_command: String::new(),
-                        source: Source {
-                            digest: SourceDigest {
-                                git_commit: String::new(),
-                                git_tree: String::new(),
-                            },
-                            uri: String::new(),
-                        },
-                    },
-                    internal_parameters: InternalParameters {
-                        evaluation: None,
-                        flake_inputs: None,
-                        lockfile_hash: Digest::Sha256 {
-                            sha256: String::new(),
-                        },
-                        toolchain: Toolchain::RustToolchain {
-                            rustc: ToolchainVersion {
-                                version: String::new(),
-                                digest: Digest::Sha256 {
-                                    sha256: String::new(),
-                                },
-                            },
-                            cargo: ToolchainVersion {
-                                version: String::new(),
-                                digest: Digest::Sha256 {
-                                    sha256: String::new(),
-                                },
-                            },
-                            kettle: ToolchainVersion {
-                                version: String::new(),
-                                digest: Digest::Sha256 {
-                                    sha256: String::new(),
-                                },
-                            },
-                        },
-                    },
-                    resolved_dependencies: vec![],
-                },
-                run_details: RunDetails {
-                    builder: Builder { id: String::new() },
-                    byproducts: vec![],
-                    metadata: Metadata {
-                        invocation_id: String::new(),
-                        started_on: String::new(),
-                        finished_on: None,
-                    },
-                },
-            },
-            subject: vec![
-                Subject {
-                    name: "a".to_string(),
-                    digest: Digest::Sha256 {
-                        sha256: checksum_a, // match
-                    },
-                },
-                Subject {
-                    name: "b".to_string(),
-                    digest: Digest::Sha256 {
-                        sha256: "bad_checksum".to_string(), // mismatch
-                    },
-                },
-                // "c" is not in subjects at all
-            ],
-        };
+        let p = provenance_with_subjects(vec![]);
+        let report = p.verify_artifacts(&[], &entries(tmp.path())).unwrap();
 
-        let mut entries: Vec<fs_err::DirEntry> = fs_err::read_dir(tmp.path())
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .collect();
-        entries.sort_by_key(|e| e.file_name());
-        let results = p.verify_artifacts(&entries).unwrap();
-        assert_eq!(results.len(), 3);
+        assert!(report.results.is_empty(), "no subjects => no results");
+        assert_eq!(report.warnings.len(), 1);
+        assert!(
+            report.warnings[0].contains("artifacts/stray"),
+            "warning: {}",
+            report.warnings[0]
+        );
+    }
 
-        // Check each result
-        let mut saw_success = false;
-        let mut saw_mismatch = false;
-        let mut saw_missing = false;
-        for r in &results {
-            match r {
-                Verification::Success { message } if message.contains("a") => saw_success = true,
-                Verification::Failure { message, .. } if message.contains("mismatch") => {
-                    saw_mismatch = true
-                }
-                Verification::Failure { message, .. } if message.contains("missing") => {
-                    saw_missing = true
-                }
-                _ => {}
-            }
-        }
-        assert!(saw_success, "expected a success for file 'a'");
-        // b has a subject but wrong checksum → mismatch
-        assert!(saw_mismatch, "expected a mismatch for file 'b'");
-        // c has no subject → missing
-        assert!(saw_missing, "expected a missing for file 'c'");
+    #[test]
+    fn verify_artifacts_unlisted_file_at_root_is_silent() {
+        // Root files are silent (unlike artifacts/ files, which warn) because
+        // provenance.json and evidence.json themselves live at the root and are
+        // not subjects.
+        let tmp = TempDir::new().unwrap();
+        write_file_to_dir(tmp.path(), "README", b"data");
+
+        let p = provenance_with_subjects(vec![]);
+        let report = p.verify_artifacts(&entries(tmp.path()), &[]).unwrap();
+
+        assert!(report.results.is_empty());
+        assert!(report.warnings.is_empty(), "root files must not warn");
     }
 
     #[test]
     fn verify_artifacts_io_error_deleted_file() {
         let tmp = TempDir::new().unwrap();
         write_file_to_dir(tmp.path(), "rg", b"content");
-        let entries: Vec<fs_err::DirEntry> = fs_err::read_dir(tmp.path())
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .collect();
-        // Delete the file after getting the DirEntry
+        let ents = entries(tmp.path());
+        // Delete the file after capturing the DirEntry.
         fs_err::remove_file(tmp.path().join("rg")).unwrap();
 
-        let p = Provenance::from_json(CARGO_FIXTURE).unwrap();
-        let result = p.verify_artifacts(&entries);
-        assert!(result.is_err(), "expected Err for deleted file");
+        let p = provenance_with_subjects(vec![sha256_subject("rg", b"content")]);
+        assert!(p.verify_artifacts(&ents, &[]).is_err());
+    }
+
+    #[test]
+    fn verify_artifacts_empty() {
+        let p = provenance_with_subjects(vec![]);
+        let report = p.verify_artifacts(&[], &[]).unwrap();
+        assert!(report.results.is_empty());
+        assert!(report.warnings.is_empty());
     }
 
     // --- Accessor methods ---


### PR DESCRIPTION
This allows artifacts to be located in the top level directory. It also inverts the code looking for artifacts to use the provenance file and then look for the named artifacts, dropping to a warning for files that aren't in the provenance but are in the artifacts/ directory.