### PR TITLE
Fix nonce size to 16 bytes

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,2 @@
 [alias]
 bin = ["run", "--package", "cargo-bin", "--"]
-deny = ["bin", "cargo-deny"]
-nextest = ["bin", "cargo-nextest"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[alias]
+bin = ["run", "--package", "cargo-bin", "--"]
+deny = ["bin", "cargo-deny"]
+nextest = ["bin", "cargo-nextest"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -149,7 +149,7 @@ jobs:
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
       - name: Attest
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest@v4
         with:
           subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}*"
       - id: cargo-dist
@@ -286,14 +286,45 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
+  publish-npm:
+    needs:
+      - plan
+      - host
+    runs-on: "ubuntu-22.04"
+    permissions:
+      id-token: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PLAN: ${{ needs.plan.outputs.val }}
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    steps:
+      - name: Fetch npm packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: artifacts-*
+          path: npm/
+          merge-multiple: true
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: |
+          for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
+            pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)
+            npm publish --access public "./npm/${pkg}"
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   announce:
     needs:
       - plan
       - host
+      - publish-npm
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-npm.result == 'skipped' || needs.publish-npm.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /crates/*/Cargo.lock
 /kettle-build
 /target
+.bin/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cargo-bin"
+version = "0.1.0"
+dependencies = [
+ "cargo-run-bin",
+]
+
+[[package]]
+name = "cargo-run-bin"
+version = "1.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba4ea665f68a2042470ec6e27a36755783ebd3367b90bec2fb100f9d5012fd8"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "clap",
+ "rustversion",
+ "serde",
+ "toml 0.5.11",
+ "toml_edit 0.19.15",
+ "version_check",
+ "which",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,7 +485,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1272,6 +1296,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hostname-validator"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,7 +1436,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -1553,6 +1586,8 @@ name = "igvm-tools"
 version = "0.2.0"
 dependencies = [
  "bitfield-struct",
+ "chrono",
+ "clap",
  "hex",
  "igvm",
  "igvm_defs",
@@ -1642,7 +1677,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1767,7 +1802,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "toml",
+ "toml 0.8.23",
  "tower",
  "tower-http",
  "tracing",
@@ -1851,6 +1886,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2185,7 +2226,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2787,6 +2828,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2794,7 +2848,7 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3433,7 +3487,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3637,6 +3691,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
@@ -3644,7 +3707,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3658,6 +3721,17 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
@@ -3667,7 +3741,7 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4148,6 +4222,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4184,7 +4270,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core",
+ "windows-core 0.57.0",
  "windows-targets 0.52.6",
 ]
 
@@ -4194,10 +4280,23 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -4205,6 +4304,17 @@ name = "windows-implement"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4223,6 +4333,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4234,9 +4361,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
- "windows-strings",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -4250,11 +4377,29 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4263,7 +4408,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4290,7 +4435,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4315,7 +4460,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4421,6 +4566,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"
@@ -4567,7 +4721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "kettle"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "attestation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,3 +116,10 @@ lto = "thin"
 tss-esapi-sys = { path = "crates/tss-esapi-sys" }
 tss-esapi = { path = "crates/tss-esapi" }
 az-cvm-vtpm = { path = "crates/az-cvm-vtpm" }
+
+[workspace]
+members = ["crates/cargo-bin"]
+
+[package.metadata.bin]
+cargo-nextest = { version = "0.9.138" }
+cargo-deny = { version = "0.19.9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kettle"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 repository = "https://github.com/confidential-dot-ai/kettle"
 build = "build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,3 +123,4 @@ members = ["crates/cargo-bin"]
 [package.metadata.bin]
 cargo-nextest = { version = "0.9.138" }
 cargo-deny = { version = "0.19.9" }
+cargo-dist = { bins = ["dist"], git = "https://github.com/frol/cargo-dist", branch = "feat/npm-trusted-publishing", version = "0.32.0" }

--- a/bin/setup
+++ b/bin/setup
@@ -6,5 +6,5 @@ set -x
 export BINSTALL_DISABLE_TELEMETRY=true
 which cargo-binstall || (curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash)
 
-which cargo-nextest || cargo binstall -y cargo-nextest
-which cargo-deny || cargo binstall -y cargo-deny
+# use cargo-binstall to install the bins configured in Cargo.toml
+cargo bin -i

--- a/crates/az-cvm-vtpm/Cargo.toml
+++ b/crates/az-cvm-vtpm/Cargo.toml
@@ -10,6 +10,7 @@
 # See Cargo.toml.orig for the original contents.
 
 [package]
+publish = false
 edition = "2021"
 name = "az-cvm-vtpm"
 version = "0.8.1"

--- a/crates/cargo-bin/Cargo.toml
+++ b/crates/cargo-bin/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cargo-bin"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+cargo-run-bin = { version = "1.7.5", features = ["cli"] }

--- a/crates/cargo-bin/Cargo.toml
+++ b/crates/cargo-bin/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cargo-bin"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
 cargo-run-bin = { version = "1.7.5", features = ["cli"] }

--- a/crates/cargo-bin/src/main.rs
+++ b/crates/cargo-bin/src/main.rs
@@ -1,0 +1,12 @@
+use std::process;
+
+fn main() {
+    let res = cargo_run_bin::cli::run();
+
+    // Only reached if run-bin code fails, otherwise process exits early from within
+    // binary::run.
+    if let Err(res) = res {
+        eprintln!("\x1b[31m{}\x1b[0m", format!("run-bin failed: {res}"));
+        process::exit(1);
+    }
+}

--- a/crates/igvm-tools/Cargo.toml
+++ b/crates/igvm-tools/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0"
 edition = "2021"
 description = "Build and measure IGVM files for confidential VMs"
 license = "Apache-2.0"
+publish = false
 
 [lib]
 name = "igvm_tools"

--- a/crates/igvm-tools/src/ovmfmeta.rs
+++ b/crates/igvm-tools/src/ovmfmeta.rs
@@ -192,10 +192,7 @@ impl OvmfMeta<'_> {
         let (g, mut m1, _) = Self::meta_blk(f)?;
 
         if g == OVMF_META_LIST {
-            loop {
-                let Some((g, b, m2)) = Self::meta_blk(m1) else {
-                    break;
-                };
+            while let Some((g, b, m2)) = Self::meta_blk(m1) {
                 ovmfmeta.parse_blk(g, b);
                 m1 = m2;
             }

--- a/crates/tss-esapi-sys/Cargo.toml
+++ b/crates/tss-esapi-sys/Cargo.toml
@@ -10,6 +10,7 @@
 # See Cargo.toml.orig for the original contents.
 
 [package]
+publish = false
 edition = "2018"
 rust-version = "1.85.0"
 name = "tss-esapi-sys"

--- a/crates/tss-esapi/Cargo.toml
+++ b/crates/tss-esapi/Cargo.toml
@@ -10,6 +10,7 @@
 # See Cargo.toml.orig for the original contents.
 
 [package]
+publish = false
 edition = "2018"
 rust-version = "1.85.0"
 name = "tss-esapi"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -3,6 +3,7 @@ members = ["cargo:."]
 
 # Config for 'dist'
 [dist]
+allow-dirty = ["ci"]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.32.0"
 # CI backends to support

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,7 +8,7 @@ cargo-dist-version = "0.31.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["shell"]
+installers = ["shell", "npm"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
 # Path that installers should place binaries in
@@ -17,7 +17,10 @@ install-path = "CARGO_HOME"
 install-updater = false
 # Whether to enable GitHub Attestations
 github-attestations = true
+# Features to pass to cargo build
 features = ["server"]
+# A namespace to use when publishing this package to the npm registry
+npm-scope = "@confidential-ai"
 
 [dist.github-action-commits]
 "actions/checkout" = "de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.31.0"
+cargo-dist-version = "0.32.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
@@ -21,6 +21,8 @@ github-attestations = true
 features = ["server"]
 # A namespace to use when publishing this package to the npm registry
 npm-scope = "@confidential-ai"
+# Which publish steps to run
+publish-jobs = ["npm"]
 
 [dist.github-action-commits]
 "actions/checkout" = "de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"

--- a/src/commands/attest.rs
+++ b/src/commands/attest.rs
@@ -164,21 +164,26 @@ mod tests {
 
     #[test]
     fn decode_nonce_accepts_exactly_16_bytes() {
-        let bytes = decode_nonce("00112233445566778899aabbccddeeff").unwrap();
-        assert_eq!(
-            bytes,
-            [
-                0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
-                0xee, 0xff
-            ]
-        );
+        let nonce: [u8; 16] = rand::random();
+        let bytes = decode_nonce(&hex::encode(nonce)).unwrap();
+        assert_eq!(bytes, nonce);
     }
 
     #[test]
     fn decode_nonce_accepts_dashed_uuid() {
         // `uuidgen` output is a dashed 16-byte value.
-        let bytes = decode_nonce("00112233-4455-6677-8899-aabbccddeeff").unwrap();
-        assert_eq!(bytes.len(), 16);
+        let nonce: [u8; 16] = rand::random();
+        let hex = hex::encode(nonce);
+        let dashed = format!(
+            "{}-{}-{}-{}-{}",
+            &hex[0..8],
+            &hex[8..12],
+            &hex[12..16],
+            &hex[16..20],
+            &hex[20..32],
+        );
+        let bytes = decode_nonce(&dashed).unwrap();
+        assert_eq!(bytes, nonce);
     }
 
     #[test]

--- a/src/commands/attest.rs
+++ b/src/commands/attest.rs
@@ -8,13 +8,34 @@ pub struct AttestArgs {
     #[arg()]
     pub path: PathBuf,
     /// Optional nonce, as hex string, to be included in the attestation.
-    /// Can be up to 16 bytes. For a unique nonce, use e.g. `uuidgen`.
+    /// Must be exactly 16 bytes (32 hex chars). For a unique nonce, use e.g.
+    /// `uuidgen`.
     #[arg(short, long)]
     pub nonce: Option<String>,
 }
 
 pub async fn attest(args: AttestArgs) -> Result<()> {
     attest_with_sink(args, &crate::toolchain::EventSink::noop()).await
+}
+
+/// Decode a user-supplied nonce hex string into the fixed 16-byte nonce slot.
+/// Dashes are stripped first so a `uuidgen` value can be pasted directly. The
+/// nonce must be exactly 16 bytes so it always fills the slot completely; a
+/// fixed width means trailing zero bytes can never reduce its randomness (see
+/// the `NONCE_LEN` note in `commands::verify`).
+// Only called from `attest_with_sink` (attest + linux) and the tests below; on
+// other targets it is exercised solely by tests, so it looks dead to a plain
+// non-test build.
+#[cfg_attr(not(all(feature = "attest", target_os = "linux")), allow(dead_code))]
+fn decode_nonce(nonce_string: &str) -> Result<[u8; 16]> {
+    let bytes = hex::decode(nonce_string.replace('-', ""))?;
+    bytes.as_slice().try_into().map_err(|_| {
+        anyhow!(
+            "Nonce {} must be exactly 16 bytes (32 hex chars); got {} bytes",
+            nonce_string,
+            bytes.len()
+        )
+    })
 }
 
 #[cfg(all(feature = "attest", target_os = "linux"))]
@@ -45,14 +66,7 @@ pub async fn attest_with_sink(args: AttestArgs, sink: &crate::toolchain::EventSi
     report_data[..32].copy_from_slice(&provenance_checksum);
 
     if let Some(nonce_string) = nonce {
-        let nonce_data = hex::decode(nonce_string.replace("-", ""))?;
-        if nonce_data.len() > 16 {
-            return Err(anyhow!(
-                "Nonce {} is too long! Must be 16 bytes (32 chars of hex) or less.",
-                nonce_string
-            ));
-        }
-        report_data[32..(32 + nonce_data.len())].copy_from_slice(&nonce_data);
+        report_data[32..].copy_from_slice(&decode_nonce(&nonce_string)?);
     };
 
     tracing::debug!("attesting with report_data {}", hex::encode(report_data));
@@ -132,4 +146,43 @@ async fn embed_snp_vcek(evidence_json: Vec<u8>) -> Result<Vec<u8>> {
     });
     tracing::info!("embedded VCEK ({} bytes) into SnpEvidence", vcek_der.len());
     Ok(serde_json::to_vec(&envelope)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_nonce_accepts_exactly_16_bytes() {
+        let bytes = decode_nonce("00112233445566778899aabbccddeeff").unwrap();
+        assert_eq!(
+            bytes,
+            [
+                0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
+                0xee, 0xff
+            ]
+        );
+    }
+
+    #[test]
+    fn decode_nonce_accepts_dashed_uuid() {
+        // `uuidgen` output is a dashed 16-byte value.
+        let bytes = decode_nonce("00112233-4455-6677-8899-aabbccddeeff").unwrap();
+        assert_eq!(bytes.len(), 16);
+    }
+
+    #[test]
+    fn decode_nonce_rejects_non_16_byte_lengths() {
+        for nonce in [
+            "",
+            "00",
+            "00112233445566778899aabbccddee",   // 15 bytes
+            "00112233445566778899aabbccddeeff00", // 17 bytes
+        ] {
+            assert!(
+                decode_nonce(nonce).is_err(),
+                "nonce {nonce:?} must be rejected"
+            );
+        }
+    }
 }

--- a/src/commands/attest.rs
+++ b/src/commands/attest.rs
@@ -7,9 +7,8 @@ pub struct AttestArgs {
     /// Path to the project to be built and attested
     #[arg()]
     pub path: PathBuf,
-    /// Optional nonce, as hex string, to be included in the attestation.
-    /// Must be exactly 16 bytes (32 hex chars). For a unique nonce, use e.g.
-    /// `uuidgen`.
+    /// Optional nonce, as hex string, to be included in the attestation. Must
+    /// be exactly 16 bytes (32 hex chars). Generate with e.g. `uuidgen`.
     #[arg(short, long)]
     pub nonce: Option<String>,
 }
@@ -18,14 +17,8 @@ pub async fn attest(args: AttestArgs) -> Result<()> {
     attest_with_sink(args, &crate::toolchain::EventSink::noop()).await
 }
 
-/// Decode a user-supplied nonce hex string into the fixed 16-byte nonce slot.
-/// Dashes are stripped first so a `uuidgen` value can be pasted directly. The
-/// nonce must be exactly 16 bytes so it always fills the slot completely; a
-/// fixed width means trailing zero bytes can never reduce its randomness (see
-/// the `NONCE_LEN` note in `commands::verify`).
-// Only called from `attest_with_sink` (attest + linux) and the tests below; on
-// other targets it is exercised solely by tests, so it looks dead to a plain
-// non-test build.
+// Decode 16-byte nonce from hex string, stripping dashes so UUIDs are allowed.
+// allow(dead_code) to prevent warnings outside of attest-mode builds and tests.
 #[cfg_attr(not(all(feature = "attest", target_os = "linux")), allow(dead_code))]
 fn decode_nonce(nonce_string: &str) -> Result<[u8; 16]> {
     let bytes = hex::decode(nonce_string.replace('-', ""))?;
@@ -50,17 +43,23 @@ pub async fn attest_with_sink(args: AttestArgs, sink: &crate::toolchain::EventSi
     println!("Running on platform: {}", platform);
     sink.emit(crate::api::Event::Attest {
         msg: format!("Running on platform: {platform}"),
-    }).await;
+    })
+    .await;
 
     let provenance_bytes = fs_err::read(path.join("kettle-build/provenance.json"))?;
     let provenance = Provenance::from_json(&provenance_bytes)?;
     let provenance_checksum = provenance.checksum();
-    println!("Attesting build provenance.json with checksum {}",
-             hex::encode(&provenance_checksum));
+    println!(
+        "Attesting build provenance.json with checksum {}",
+        hex::encode(&provenance_checksum)
+    );
     sink.emit(crate::api::Event::Attest {
-        msg: format!("Attesting provenance.json (checksum {})",
-                     hex::encode(&provenance_checksum)),
-    }).await;
+        msg: format!(
+            "Attesting provenance.json (checksum {})",
+            hex::encode(&provenance_checksum)
+        ),
+    })
+    .await;
 
     let mut report_data = [0u8; 48];
     report_data[..32].copy_from_slice(&provenance_checksum);
@@ -79,13 +78,17 @@ pub async fn attest_with_sink(args: AttestArgs, sink: &crate::toolchain::EventSi
     println!("Attestation complete! Evidence written to file `evidence.json`");
     sink.emit(crate::api::Event::Attest {
         msg: "Attestation complete! evidence.json written".into(),
-    }).await;
+    })
+    .await;
 
     Ok(())
 }
 
 #[cfg(not(all(feature = "attest", target_os = "linux")))]
-pub async fn attest_with_sink(_args: AttestArgs, _sink: &crate::toolchain::EventSink) -> Result<()> {
+pub async fn attest_with_sink(
+    _args: AttestArgs,
+    _sink: &crate::toolchain::EventSink,
+) -> Result<()> {
     Err(anyhow!(
         "Attestation is disabled. Rebuild Kettle with `--features attest` to enable this command."
     ))
@@ -96,7 +99,7 @@ pub async fn attest_with_sink(_args: AttestArgs, _sink: &crate::toolchain::Event
 // we fetch the VCEK here and embed it before writing the evidence.
 #[cfg(all(feature = "attest", target_os = "linux"))]
 async fn embed_snp_vcek(evidence_json: Vec<u8>) -> Result<Vec<u8>> {
-    use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+    use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
     use sev::firmware::guest::AttestationReport;
     use sev::parser::ByteParser;
 
@@ -104,7 +107,9 @@ async fn embed_snp_vcek(evidence_json: Vec<u8>) -> Result<Vec<u8>> {
     if envelope.get("platform").and_then(|p| p.as_str()) != Some("snp") {
         return Ok(evidence_json);
     }
-    let evidence = envelope.get_mut("evidence").ok_or_else(|| anyhow!("evidence missing"))?;
+    let evidence = envelope
+        .get_mut("evidence")
+        .ok_or_else(|| anyhow!("evidence missing"))?;
     if !evidence.get("cert_chain").is_some_and(|c| c.is_null()) {
         return Ok(evidence_json);
     }
@@ -112,14 +117,18 @@ async fn embed_snp_vcek(evidence_json: Vec<u8>) -> Result<Vec<u8>> {
         .get("attestation_report")
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("attestation_report missing"))?;
-    let report_bytes = BASE64.decode(report_b64).map_err(|e| anyhow!("report base64: {e}"))?;
+    let report_bytes = BASE64
+        .decode(report_b64)
+        .map_err(|e| anyhow!("report base64: {e}"))?;
     let report = AttestationReport::from_bytes(&report_bytes)
         .map_err(|e| anyhow!("SNP report parse: {e}"))?;
 
     let cpuid_fam = report.cpuid_fam_id.unwrap_or(0);
     let cpuid_mod = report.cpuid_mod_id.unwrap_or(0);
     let processor_gen = attestation::ProcessorGeneration::from_cpuid(cpuid_fam, cpuid_mod)
-        .ok_or_else(|| anyhow!("unknown SNP processor family={cpuid_fam:#x} model={cpuid_mod:#x}"))?;
+        .ok_or_else(|| {
+            anyhow!("unknown SNP processor family={cpuid_fam:#x} model={cpuid_mod:#x}")
+        })?;
 
     let mut chip_id = [0u8; 64];
     chip_id.copy_from_slice(&report.chip_id[..]);
@@ -136,9 +145,10 @@ async fn embed_snp_vcek(evidence_json: Vec<u8>) -> Result<Vec<u8>> {
     };
 
     let provider = attestation::DefaultCertProvider::new();
-    let vcek_der = attestation::CertProvider::get_snp_vcek(&provider, processor_gen, &chip_id, &tcb)
-        .await
-        .map_err(|e| anyhow!("VCEK fetch from AMD KDS failed: {e}"))?;
+    let vcek_der =
+        attestation::CertProvider::get_snp_vcek(&provider, processor_gen, &chip_id, &tcb)
+            .await
+            .map_err(|e| anyhow!("VCEK fetch from AMD KDS failed: {e}"))?;
     evidence["cert_chain"] = serde_json::json!({
         "vcek": BASE64.encode(&vcek_der),
         "ask": null,
@@ -176,7 +186,7 @@ mod tests {
         for nonce in [
             "",
             "00",
-            "00112233445566778899aabbccddee",   // 15 bytes
+            "00112233445566778899aabbccddee",     // 15 bytes
             "00112233445566778899aabbccddeeff00", // 17 bytes
         ] {
             assert!(

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -522,13 +522,14 @@ mod tests {
     #[test]
     fn verify_provenance_mismatch_shows_attested_checksum() {
         let provenance = Provenance::from_json(CARGO_FIXTURE).unwrap();
-        let signed_data = vec![0xab; 32];
-        let vr = make_verification_result(true, signed_data);
+        // A random checksum that won't match the fixture's real one.
+        let signed_data: [u8; 32] = rand::random();
+        let vr = make_verification_result(true, signed_data.to_vec());
         match verify_provenance(&vr, &provenance) {
             Verification::Failure { message, details } => {
                 assert!(message.contains("mismatch"), "message: {message}");
                 assert!(
-                    details.contains(&"ab".repeat(32)),
+                    details.contains(&hex::encode(signed_data)),
                     "details should show the attested checksum hex: {details}"
                 );
             }
@@ -567,7 +568,8 @@ mod tests {
     /// 16-byte nonce, with trailing nulls stripped.
     fn assert_verify_real_nonce(nonce: [u8; 16]) {
         let mut report_data = [0u8; 48];
-        report_data[..32].copy_from_slice(&[0xab; 32]);
+        // Random checksum; only the nonce half matters to this test.
+        report_data[..32].copy_from_slice(&rand::random::<[u8; 32]>());
         report_data[32..].copy_from_slice(&nonce);
 
         // Mirror attestation's strip_trailing_nulls on the full report_data.

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -553,7 +553,7 @@ mod tests {
         let nonce_bytes = hex::decode(nonce).unwrap();
         assert_eq!(nonce_bytes.len(), 16, "test nonce must be exactly 16 bytes");
 
-        let mut report_data = vec![0u8; 48];
+        let mut report_data = [0u8; 48];
         report_data[..32].copy_from_slice(&[0xab; 32]);
         report_data[32..].copy_from_slice(&nonce_bytes);
 
@@ -667,7 +667,7 @@ mod tests {
     /// library does when producing `signed_data`).
     fn signed_data_for(checksum: &[u8], nonce: Option<&[u8]>) -> Vec<u8> {
         assert_eq!(checksum.len(), 32, "checksum must be 32 bytes");
-        let mut report_data = vec![0u8; 48];
+        let mut report_data = [0u8; 48];
         report_data[..32].copy_from_slice(checksum);
         if let Some(n) = nonce {
             assert_eq!(n.len(), 16, "nonce must be 16 bytes");

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -18,7 +18,7 @@ pub struct VerifyArgs {
     #[arg()]
     path: PathBuf,
     /// Optional nonce, as hex string, to be checked against the attestation.
-    /// Can be up to 16 bytes.
+    /// Must be exactly 16 bytes (32 hex chars).
     #[arg(short, long)]
     nonce: Option<String>,
     /// Path to the IGVM file the CVM booted from. When set, verifies that the
@@ -144,25 +144,58 @@ fn build_dir_name(path: &Path) -> String {
         .unwrap_or_else(|| path.to_string_lossy().into_owned())
 }
 
+/// Every nonce is exactly this many bytes. A fixed width means the verifier
+/// always knows where the nonce ends, so trailing zero bytes are restored
+/// deterministically (see `verify_nonce`) and can never reduce the nonce's
+/// effective randomness.
+const NONCE_LEN: usize = 16;
+
 fn verify_nonce(verification_result: &VerificationResult, nonce_string: String) -> Verification {
-    let nonce = hex::decode(nonce_string).unwrap();
-    if let Some(signed_data) = &verification_result.claims.signed_data.split_at_checked(32) {
-        let signed_nonce = signed_data.1;
+    let nonce = match hex::decode(&nonce_string) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            return Verification::failure(
+                "Invalid nonce hex",
+                &format!("Could not decode nonce {nonce_string:?} as hex: {e}"),
+            );
+        }
+    };
+    if nonce.len() != NONCE_LEN {
+        return Verification::failure(
+            &format!("Nonce must be exactly {NONCE_LEN} bytes"),
+            &format!(
+                "Expected {NONCE_LEN} bytes ({} hex chars); got {} bytes",
+                NONCE_LEN * 2,
+                nonce.len()
+            ),
+        );
+    }
+
+    if let Some((_, signed_nonce)) = verification_result.claims.signed_data.split_at_checked(32) {
+        // The attestation library strips trailing null bytes from `signed_data`,
+        // so the nonce region may be shorter than the fixed-width slot it was
+        // written into. Zero-extend it back to NONCE_LEN and compare in full; a
+        // region longer than the slot can never be a valid nonce.
+        let matches = signed_nonce.len() <= NONCE_LEN && {
+            let mut padded = [0u8; NONCE_LEN];
+            padded[..signed_nonce.len()].copy_from_slice(signed_nonce);
+            padded.as_slice() == nonce.as_slice()
+        };
 
         tracing::debug!(
             "signed_nonce {:?} given nonce {:?} equal {}",
             hex::encode(signed_nonce),
             hex::encode(&nonce),
-            signed_nonce == nonce
+            matches
         );
 
-        match signed_nonce == nonce {
+        match matches {
             true => Verification::success("Nonce matches attestation"),
             false => Verification::failure(
                 "Nonce mismatch",
                 &format!(
                     "Expected attested nonce {:?}\nActual value was        {:?}",
-                    hex::encode(nonce),
+                    hex::encode(&nonce),
                     hex::encode(signed_nonce)
                 ),
             ),
@@ -515,58 +548,110 @@ mod tests {
         }
     }
 
+    // A 16-byte nonce always verifies against a *real* attestation, including
+    // one that ends in zero bytes. `attest` writes the nonce into the 16-byte
+    // report_data slot; the attestation library then strips trailing null bytes
+    // when producing `signed_data`. Verification zero-extends the signed nonce
+    // back to the known 16-byte width and compares in full, so trailing zeros
+    // are always significant and never reduce the nonce's effective randomness.
     #[test]
     fn verify_signed_nonce() {
-        assert_verify_nonce("");
-        assert_verify_nonce("aa");
-        assert_verify_nonce("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-        assert_verify_nonce("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-        assert_verify_nonce("deadbeefdeadbeefdeadbeefdeadbeef");
-        assert_verify_nonce("43C4EF48E21A45B886B2FA7D7CD0EF59");
-        assert_verify_nonce("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-        assert_verify_nonce("00");
-        assert_verify_nonce("000000000000000000000000000000");
-        assert_verify_nonce("00000000000000000000000000000000");
-        assert_verify_nonce("0000000000000000000000000000000000");
+        assert_verify_real_nonce("deadbeefdeadbeefdeadbeefdeadbeef");
+        assert_verify_real_nonce("43c4ef48e21a45b886b2fa7d7cd0ef59");
+        assert_verify_real_nonce("ffffffffffffffffffffffffffffffff");
+        // ends in a single zero byte (one byte stripped, one zero-extended)
+        assert_verify_real_nonce("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00");
+        // ends in several zero bytes (most stripping, most zero-extension)
+        assert_verify_real_nonce("deadbeefdeadbeefdeadbeef00000000");
     }
 
-    fn assert_verify_nonce(nonce: &str) {
-        let mut signed_data = vec![0; 32];
-        let mut nonce_bytes = hex::decode(nonce).unwrap();
-        signed_data.append(&mut nonce_bytes);
+    /// Build `signed_data` like attest does: 32-byte checksum followed by
+    /// 16-byte nonce, with trailing nulls stripped.
+    fn assert_verify_real_nonce(nonce: &str) {
+        let nonce_bytes = hex::decode(nonce).unwrap();
+        assert_eq!(nonce_bytes.len(), 16, "test nonce must be exactly 16 bytes");
+
+        let mut report_data = vec![0u8; 48];
+        report_data[..32].copy_from_slice(&[0xab; 32]);
+        report_data[32..].copy_from_slice(&nonce_bytes);
+
+        // Mirror attestation's strip_trailing_nulls on the full report_data.
+        let end = report_data
+            .iter()
+            .rposition(|&b| b != 0)
+            .map_or(0, |i| i + 1);
+        let signed_data = report_data[..end].to_vec();
 
         let vr = make_verification_result(true, signed_data);
         match verify_nonce(&vr, nonce.to_string()) {
             Verification::Success { message } => {
                 assert!(message.contains("match"), "message: {message}");
             }
-            Verification::Failure { message, .. } => panic!("expected success: {message}"),
+            Verification::Failure { message, .. } => {
+                panic!("expected success for nonce {nonce:?}: {message}")
+            }
+        }
+    }
+
+    // An expected nonce that is not exactly 16 bytes is rejected outright. The
+    // whole point of the fixed size is that every nonce is 16 bytes, so a short
+    // (or over-long) value is never silently accepted with reduced entropy.
+    #[test]
+    fn verify_nonce_rejects_non_16_byte_expected() {
+        let mut signed_data = vec![0xab; 32];
+        signed_data.extend_from_slice(&[0xcd; 16]);
+        for nonce in [
+            "",
+            "cd",
+            "cdcdcdcd",
+            "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",   // 15 bytes
+            "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd", // 17 bytes
+        ] {
+            let vr = make_verification_result(true, signed_data.clone());
+            match verify_nonce(&vr, nonce.to_string()) {
+                Verification::Failure { message, .. } => {
+                    assert!(message.contains("16 bytes"), "nonce {nonce:?}: {message}");
+                }
+                Verification::Success { .. } => {
+                    panic!("expected failure for non-16-byte nonce {nonce:?}")
+                }
+            }
+        }
+    }
+
+    // A malformed (non-hex) expected nonce is reported as a failure, not a panic.
+    #[test]
+    fn verify_nonce_rejects_invalid_hex() {
+        let mut signed_data = vec![0xab; 32];
+        signed_data.extend_from_slice(&[0xcd; 16]);
+        for nonce in ["zz", "deadbeefg", "not hex at all"] {
+            let vr = make_verification_result(true, signed_data.clone());
+            match verify_nonce(&vr, nonce.to_string()) {
+                Verification::Failure { message, .. } => {
+                    assert!(message.contains("hex"), "nonce {nonce:?}: {message}");
+                }
+                Verification::Success { .. } => {
+                    panic!("expected failure for non-hex nonce {nonce:?}")
+                }
+            }
         }
     }
 
     #[test]
     fn verify_signed_nonce_errors() {
-        assert_verify_nonce_fails(vec![], "", "missing");
-        assert_verify_nonce_fails(vec![0; 3], "", "missing");
-        assert_verify_nonce_fails(vec![0; 31], "", "missing");
-        assert_verify_nonce_fails(vec![0; 33], "", "mismatch");
-        assert_verify_nonce_fails(vec![0; 49], "", "mismatch");
-        assert_verify_nonce_fails(vec![0; 50], "", "mismatch");
-        assert_verify_nonce_fails(vec![0; 51], "", "mismatch");
-        assert_verify_nonce_fails(vec![0; 64], "", "mismatch");
-        assert_verify_nonce_fails(vec![0; 65], "", "mismatch");
+        // A valid 16-byte expected nonce, but signed_data has no room for one.
+        let nonce = "deadbeefdeadbeefdeadbeefdeadbeef";
+        assert_verify_nonce_fails(vec![], nonce, "missing");
+        assert_verify_nonce_fails(vec![0; 3], nonce, "missing");
+        assert_verify_nonce_fails(vec![0; 31], nonce, "missing");
 
-        assert_verify_nonce_fails(vec![], "cafe", "missing");
-        assert_verify_nonce_fails(vec![0; 3], "cafe", "missing");
-        assert_verify_nonce_fails(vec![0; 31], "cafe", "missing");
-        assert_verify_nonce_fails(vec![0; 33], "cafe", "mismatch");
-        assert_verify_nonce_fails(vec![0; 49], "cafe", "mismatch");
-        assert_verify_nonce_fails(vec![0; 50], "cafe", "mismatch");
-        assert_verify_nonce_fails(vec![0; 51], "cafe", "mismatch");
-        assert_verify_nonce_fails(vec![0; 64], "cafe", "mismatch");
-        assert_verify_nonce_fails(vec![0; 65], "cafe", "mismatch");
-
-        assert_verify_nonce_fails(vec![0; 50], "aa000000000000000000000000000000", "mismatch");
+        // Long enough to split, but the attested nonce (zero-extended to 16
+        // bytes) differs from the expected one -> mismatch.
+        assert_verify_nonce_fails(vec![0xab; 33], nonce, "mismatch");
+        assert_verify_nonce_fails(vec![0xab; 48], nonce, "mismatch");
+        // An over-long nonce region (more than 16 bytes) can never match.
+        assert_verify_nonce_fails(vec![0xab; 49], nonce, "mismatch");
+        assert_verify_nonce_fails(vec![0xab; 65], nonce, "mismatch");
     }
 
     fn assert_verify_nonce_fails(signed_data: Vec<u8>, nonce: &str, needle: &str) {

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -538,24 +538,37 @@ mod tests {
 
     #[test]
     fn verify_signed_nonce() {
-        assert_verify_real_nonce("deadbeefdeadbeefdeadbeefdeadbeef");
-        assert_verify_real_nonce("43c4ef48e21a45b886b2fa7d7cd0ef59");
-        assert_verify_real_nonce("ffffffffffffffffffffffffffffffff");
-        // ensure zero bytes still verify correctly
-        assert_verify_real_nonce("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00");
-        // ends in several zero bytes (most stripping, most zero-extension)
-        assert_verify_real_nonce("deadbeefdeadbeefdeadbeef00000000");
+        // A nonce with no trailing zero bytes (nothing gets stripped).
+        let mut no_trailing_zeros = random_nonce();
+        no_trailing_zeros[15] |= 1;
+        assert_verify_real_nonce(no_trailing_zeros);
+
+        // A couple of fully arbitrary nonces.
+        assert_verify_real_nonce(random_nonce());
+        assert_verify_real_nonce(random_nonce());
+
+        // Ends in a single zero byte (some stripping, some zero-extension).
+        let mut one_trailing_zero = random_nonce();
+        one_trailing_zero[15] = 0;
+        assert_verify_real_nonce(one_trailing_zero);
+
+        // Ends in several zero bytes (most stripping, most zero-extension).
+        let mut many_trailing_zeros = random_nonce();
+        many_trailing_zeros[12..].fill(0);
+        assert_verify_real_nonce(many_trailing_zeros);
+    }
+
+    /// A random 16-byte nonce, the size attest produces.
+    fn random_nonce() -> [u8; 16] {
+        rand::random()
     }
 
     /// Build `signed_data` like attest does: 32-byte checksum followed by
     /// 16-byte nonce, with trailing nulls stripped.
-    fn assert_verify_real_nonce(nonce: &str) {
-        let nonce_bytes = hex::decode(nonce).unwrap();
-        assert_eq!(nonce_bytes.len(), 16, "test nonce must be exactly 16 bytes");
-
+    fn assert_verify_real_nonce(nonce: [u8; 16]) {
         let mut report_data = [0u8; 48];
         report_data[..32].copy_from_slice(&[0xab; 32]);
-        report_data[32..].copy_from_slice(&nonce_bytes);
+        report_data[32..].copy_from_slice(&nonce);
 
         // Mirror attestation's strip_trailing_nulls on the full report_data.
         let end = report_data
@@ -565,7 +578,7 @@ mod tests {
         let signed_data = report_data[..end].to_vec();
 
         let vr = make_verification_result(true, signed_data);
-        match verify_nonce(&vr, nonce.to_string()) {
+        match verify_nonce(&vr, hex::encode(nonce)) {
             Verification::Success { message } => {
                 assert!(message.contains("match"), "message: {message}");
             }
@@ -619,7 +632,8 @@ mod tests {
     #[test]
     fn verify_signed_nonce_errors() {
         // A valid 16-byte expected nonce, but signed_data has no room for one.
-        let nonce = "deadbeefdeadbeefdeadbeefdeadbeef";
+        let nonce = hex::encode(random_nonce());
+        let nonce = nonce.as_str();
         assert_verify_nonce_fails(vec![], nonce, "missing");
         assert_verify_nonce_fails(vec![0; 3], nonce, "missing");
         assert_verify_nonce_fails(vec![0; 31], nonce, "missing");
@@ -718,7 +732,7 @@ mod tests {
     fn verify_checksum_and_nonce_both_ending_in_zeros() {
         let mut checksum = vec![0xab; 32];
         checksum[31] = 0x00;
-        let mut nonce = vec![0x11; 16];
+        let mut nonce = random_nonce().to_vec();
         nonce[14] = 0x00;
         nonce[15] = 0x00;
         let signed_data = signed_data_for(&checksum, Some(&nonce));

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -144,10 +144,7 @@ fn build_dir_name(path: &Path) -> String {
         .unwrap_or_else(|| path.to_string_lossy().into_owned())
 }
 
-/// Every nonce is exactly this many bytes. A fixed width means the verifier
-/// always knows where the nonce ends, so trailing zero bytes are restored
-/// deterministically (see `verify_nonce`) and can never reduce the nonce's
-/// effective randomness.
+// Fixed-size nonces to prevent padding issues.
 const NONCE_LEN: usize = 16;
 
 fn verify_nonce(verification_result: &VerificationResult, nonce_string: String) -> Verification {
@@ -172,10 +169,7 @@ fn verify_nonce(verification_result: &VerificationResult, nonce_string: String) 
     }
 
     if let Some((_, signed_nonce)) = verification_result.claims.signed_data.split_at_checked(32) {
-        // The attestation library strips trailing null bytes from `signed_data`,
-        // so the nonce region may be shorter than the fixed-width slot it was
-        // written into. Zero-extend it back to NONCE_LEN and compare in full; a
-        // region longer than the slot can never be a valid nonce.
+        // The attestation library may have removed trailing null bytes, add them if necessary.
         let matches = signed_nonce.len() <= NONCE_LEN && {
             let mut padded = [0u8; NONCE_LEN];
             padded[..signed_nonce.len()].copy_from_slice(signed_nonce);
@@ -282,8 +276,7 @@ fn compare_roothash(igvm_roothash: &str, disk_roothash: &str) -> Verification {
 }
 
 /// Verify that the dm-verity roothash committed inside the IGVM matches the
-/// roothash stored in the disk image. Reported as a verification failure (never
-/// a panic) on any structural problem.
+/// roothash stored in the disk image.
 fn verify_image_roothash(igvm_path: &Path, image_path: &Path) -> Verification {
     let bytes = match fs_err::read(igvm_path) {
         Ok(b) => b,
@@ -304,7 +297,7 @@ fn verify_image_roothash(igvm_path: &Path, image_path: &Path) -> Verification {
     let disk_roothash = match crate::verity::stored_roothash(image_path) {
         Ok(r) => r,
         Err(e) => {
-            return Verification::failure("Could not read disk image roothash", &e.to_string())
+            return Verification::failure("Could not read disk image roothash", &e.to_string());
         }
     };
     compare_roothash(&igvm_roothash, &disk_roothash)
@@ -314,48 +307,46 @@ fn verify_provenance(
     verification_result: &VerificationResult,
     provenance: &Provenance,
 ) -> Verification {
-    if let Some(signed_data) = &verification_result.claims.signed_data.split_at_checked(32) {
-        let signed_checksum = signed_data.0;
-        if signed_checksum.len() != 32 {
-            return Verification::Failure {
-                message: "Attested checksum invalid".to_string(),
-                details: format!(
-                    "Expected attestation checksum {:?} to be 32 bytes",
-                    hex::encode(signed_checksum)
-                ),
-            };
-        }
+    compare_checksum(
+        &verification_result.claims.signed_data,
+        &provenance.checksum(),
+    )
+}
 
-        let checksum = provenance.checksum();
-        if checksum.len() != 32 {
-            return Verification::Failure {
-                message: "Provenance checksum invalid".to_string(),
-                details: format!(
-                    "Expected provenance.json checksum {:?} to be 32 bytes",
-                    hex::encode(checksum)
-                ),
-            };
-        }
-
-        match signed_checksum == checksum {
-            true => Verification::success("Provenance checksum match"),
-            false => Verification::failure(
-                "Provenance checksum mismatch",
-                &format!(
-                    "Expected provenance.json checksum {:?}\nActual provenance.json checksum   {:?}",
-                    hex::encode(signed_checksum),
-                    hex::encode(checksum)
-                ),
-            ),
-        }
-    } else {
-        Verification::Failure {
-            message: "Signed data invalid".to_owned(),
+/// Compare the attested provenance checksum (the first 32 bytes of report_data)
+/// against the expected provenance.json checksum.
+///
+/// The checksum occupies the first 32 bytes of the fixed 48-byte report_data,
+/// but the attestation library strips trailing null bytes from `signed_data`. A
+/// checksum ending in zeros — with no nonce, or an all-zero nonce slot — comes
+/// back shorter than 32 bytes. Zero-extend the signed checksum back to the fixed
+/// 32-byte width (the same trick `verify_nonce` uses) so trailing zeros are
+/// restored deterministically and such a checksum still verifies.
+fn compare_checksum(signed_data: &[u8], expected: &[u8]) -> Verification {
+    if expected.len() != 32 {
+        return Verification::Failure {
+            message: "Provenance checksum invalid".to_string(),
             details: format!(
-                "Expected signed data {:?} to be at least 32 bytes",
-                &verification_result.claims.signed_data
+                "Expected provenance.json checksum {:?} to be 32 bytes",
+                hex::encode(expected)
             ),
-        }
+        };
+    }
+
+    let mut signed_checksum = [0u8; 32];
+    let n = signed_data.len().min(32);
+    signed_checksum[..n].copy_from_slice(&signed_data[..n]);
+
+    match signed_checksum.as_slice() == expected {
+        true => Verification::success("Provenance checksum match"),
+        false => Verification::failure(
+            "Provenance checksum mismatch",
+            &format!(
+                "Expected provenance.json checksum {:?}\nActual attested checksum          {:?}",
+                hex::encode(expected),
+                hex::encode(signed_checksum)
+            ),
+        ),
     }
 }
 
@@ -372,16 +363,13 @@ impl Build {
         let evidence_bytes = fs_err::read(project_dir.join("evidence.json"))?;
         let provenance_bytes = fs_err::read(project_dir.join("provenance.json"))?;
 
-        // Regular files sitting directly in the build dir — e.g. a binary
-        // published by `oras` alongside provenance.json. Subdirectories such as
-        // `artifacts/` are not regular files and are excluded here.
+        // binaries are allowed to be at the top level
         let top_level = fs_err::read_dir(&project_dir)?
             .filter_map(|e| e.ok())
             .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
             .collect();
 
-        // `artifacts/` is optional: classic builds use it, oras-published
-        // builds may not have it at all. Its absence is not an error.
+        // binaries are also allowed to be inside `artifacts/`
         let artifacts_dir = project_dir.join("artifacts");
         let artifacts = if artifacts_dir.is_dir() {
             fs_err::read_dir(artifacts_dir)?
@@ -548,18 +536,12 @@ mod tests {
         }
     }
 
-    // A 16-byte nonce always verifies against a *real* attestation, including
-    // one that ends in zero bytes. `attest` writes the nonce into the 16-byte
-    // report_data slot; the attestation library then strips trailing null bytes
-    // when producing `signed_data`. Verification zero-extends the signed nonce
-    // back to the known 16-byte width and compares in full, so trailing zeros
-    // are always significant and never reduce the nonce's effective randomness.
     #[test]
     fn verify_signed_nonce() {
         assert_verify_real_nonce("deadbeefdeadbeefdeadbeefdeadbeef");
         assert_verify_real_nonce("43c4ef48e21a45b886b2fa7d7cd0ef59");
         assert_verify_real_nonce("ffffffffffffffffffffffffffffffff");
-        // ends in a single zero byte (one byte stripped, one zero-extended)
+        // ensure zero bytes still verify correctly
         assert_verify_real_nonce("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00");
         // ends in several zero bytes (most stripping, most zero-extension)
         assert_verify_real_nonce("deadbeefdeadbeefdeadbeef00000000");
@@ -593,9 +575,6 @@ mod tests {
         }
     }
 
-    // An expected nonce that is not exactly 16 bytes is rejected outright. The
-    // whole point of the fixed size is that every nonce is 16 bytes, so a short
-    // (or over-long) value is never silently accepted with reduced entropy.
     #[test]
     fn verify_nonce_rejects_non_16_byte_expected() {
         let mut signed_data = vec![0xab; 32];
@@ -604,7 +583,7 @@ mod tests {
             "",
             "cd",
             "cdcdcdcd",
-            "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",   // 15 bytes
+            "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",     // 15 bytes
             "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd", // 17 bytes
         ] {
             let vr = make_verification_result(true, signed_data.clone());
@@ -666,16 +645,9 @@ mod tests {
 
     #[test]
     fn verify_signed_checksum_errors() {
-        assert_verify_provenance_fails(vec![], "invalid");
-        assert_verify_provenance_fails(vec![0; 3], "invalid");
-        assert_verify_provenance_fails(vec![0; 31], "invalid");
-        assert_verify_provenance_fails(vec![0; 32], "mismatch");
-        assert_verify_provenance_fails(vec![0; 33], "mismatch");
-        assert_verify_provenance_fails(vec![0; 49], "mismatch");
-        assert_verify_provenance_fails(vec![0; 50], "mismatch");
-        assert_verify_provenance_fails(vec![0; 51], "mismatch");
-        assert_verify_provenance_fails(vec![0; 64], "mismatch");
-        assert_verify_provenance_fails(vec![0; 65], "mismatch");
+        for len in [0, 3, 31, 32, 33, 49, 50, 51, 64, 65] {
+            assert_verify_provenance_fails(vec![0; len], "mismatch");
+        }
     }
 
     fn assert_verify_provenance_fails(signed_data: Vec<u8>, needle: &str) {
@@ -686,6 +658,77 @@ mod tests {
                 assert!(message.contains(needle), "message: {message}");
             }
             Verification::Success { .. } => panic!("expected failure"),
+        }
+    }
+
+    /// Build `signed_data` exactly as the real attest pipeline does for a given
+    /// 32-byte checksum and optional 16-byte nonce: lay them into the 48-byte
+    /// report_data slot, then strip all trailing null bytes (as the attestation
+    /// library does when producing `signed_data`).
+    fn signed_data_for(checksum: &[u8], nonce: Option<&[u8]>) -> Vec<u8> {
+        assert_eq!(checksum.len(), 32, "checksum must be 32 bytes");
+        let mut report_data = vec![0u8; 48];
+        report_data[..32].copy_from_slice(checksum);
+        if let Some(n) = nonce {
+            assert_eq!(n.len(), 16, "nonce must be 16 bytes");
+            report_data[32..].copy_from_slice(n);
+        }
+        let end = report_data
+            .iter()
+            .rposition(|&b| b != 0)
+            .map_or(0, |i| i + 1);
+        report_data[..end].to_vec()
+    }
+
+    fn assert_checksum_matches(signed_data: &[u8], expected: &[u8]) {
+        match compare_checksum(signed_data, expected) {
+            Verification::Success { message } => assert!(message.contains("match"), "{message}"),
+            Verification::Failure { message, details } => {
+                panic!("expected checksum success: {message}\n{details}")
+            }
+        }
+    }
+
+    #[test]
+    fn verify_checksum_ending_in_zeros_without_nonce() {
+        let mut checksum = vec![0xab; 32];
+        checksum[30] = 0x00;
+        checksum[31] = 0x00;
+        let signed_data = signed_data_for(&checksum, None);
+        assert!(
+            signed_data.len() < 32,
+            "precondition: the checksum tail should be stripped (got {} bytes)",
+            signed_data.len()
+        );
+        assert_checksum_matches(&signed_data, &checksum);
+    }
+
+    #[test]
+    fn verify_checksum_leading_and_trailing_zeros_without_nonce() {
+        let mut checksum = vec![0xcd; 32];
+        checksum[0] = 0x00;
+        checksum[1] = 0x00;
+        checksum[30] = 0x00;
+        checksum[31] = 0x00;
+        let signed_data = signed_data_for(&checksum, None);
+        assert_checksum_matches(&signed_data, &checksum);
+    }
+
+    #[test]
+    fn verify_checksum_and_nonce_both_ending_in_zeros() {
+        let mut checksum = vec![0xab; 32];
+        checksum[31] = 0x00;
+        let mut nonce = vec![0x11; 16];
+        nonce[14] = 0x00;
+        nonce[15] = 0x00;
+        let signed_data = signed_data_for(&checksum, Some(&nonce));
+
+        assert_checksum_matches(&signed_data, &checksum);
+
+        let vr = make_verification_result(true, signed_data);
+        match verify_nonce(&vr, hex::encode(&nonce)) {
+            Verification::Success { message } => assert!(message.contains("match"), "{message}"),
+            Verification::Failure { message, .. } => panic!("expected nonce success: {message}"),
         }
     }
 
@@ -790,7 +833,10 @@ mod tests {
     #[test]
     fn build_dir_name_falls_back_for_nonexistent_path() {
         // canonicalize fails, so we fall back to the path as given.
-        assert_eq!(build_dir_name(Path::new("does-not-exist")), "does-not-exist");
+        assert_eq!(
+            build_dir_name(Path::new("does-not-exist")),
+            "does-not-exist"
+        );
     }
 
     // --- verify_igvm_measurement (digest comparison) ---

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -756,7 +756,6 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         fs_err::write(tmp.path().join("evidence.json"), b"{}").unwrap();
         fs_err::write(tmp.path().join("provenance.json"), CARGO_FIXTURE).unwrap();
-        // oras-style: binary dropped directly beside provenance.json, no artifacts/
         fs_err::write(tmp.path().join("rg"), b"binary").unwrap();
 
         let build = Build::from_dir(&tmp.path().to_path_buf()).unwrap();
@@ -787,7 +786,6 @@ mod tests {
 
     #[test]
     fn build_from_dir_missing_artifacts_is_ok() {
-        // artifacts/ is optional now: absence is not an error.
         let tmp = TempDir::new().unwrap();
         fs_err::write(tmp.path().join("evidence.json"), b"{}").unwrap();
         fs_err::write(tmp.path().join("provenance.json"), CARGO_FIXTURE).unwrap();
@@ -814,7 +812,6 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let nested = tmp.path().join("my-build");
         fs_err::create_dir(&nested).unwrap();
-        // `.` has no `file_name()` component; this used to panic.
         let prev = std::env::current_dir().unwrap();
         std::env::set_current_dir(&nested).unwrap();
         let name = build_dir_name(Path::new("."));

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -90,9 +90,10 @@ mod tests {
 
     #[test]
     fn validate_nonce_accepts_exactly_16_bytes() {
-        let bytes = validate_nonce("00112233445566778899aabbccddeeff")
+        let nonce: [u8; 16] = rand::random();
+        let bytes = validate_nonce(&hex::encode(nonce))
             .expect("16-byte nonce must be accepted");
-        assert_eq!(bytes.len(), 16);
+        assert_eq!(bytes, nonce);
     }
 
     #[test]

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -52,8 +52,8 @@ pub async fn post_build(
 fn validate_nonce(nonce: &str) -> Result<Vec<u8>, (StatusCode, String)> {
     let bytes = hex::decode(nonce)
         .map_err(|e| (StatusCode::BAD_REQUEST, format!("invalid nonce hex: {e}")))?;
-    if bytes.len() > 16 {
-        return Err((StatusCode::BAD_REQUEST, "nonce must be at most 16 bytes".into()));
+    if bytes.len() != 16 {
+        return Err((StatusCode::BAD_REQUEST, "nonce must be exactly 16 bytes".into()));
     }
     Ok(bytes)
 }
@@ -82,6 +82,33 @@ pub async fn get_events(
 
 fn to_sse(event: crate::api::Event) -> SseEvent {
     SseEvent::default().data(serde_json::to_string(&event).unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_nonce_accepts_exactly_16_bytes() {
+        let bytes = validate_nonce("00112233445566778899aabbccddeeff")
+            .expect("16-byte nonce must be accepted");
+        assert_eq!(bytes.len(), 16);
+    }
+
+    #[test]
+    fn validate_nonce_rejects_non_16_byte_lengths() {
+        for nonce in [
+            "",
+            "00",
+            "00112233445566778899aabbccddee",   // 15 bytes
+            "00112233445566778899aabbccddeeff00", // 17 bytes
+        ] {
+            let (status, msg) = validate_nonce(nonce)
+                .expect_err(&format!("nonce {nonce:?} must be rejected"));
+            assert_eq!(status, StatusCode::BAD_REQUEST, "nonce {nonce:?}");
+            assert!(msg.contains("16 bytes"), "nonce {nonce:?}: {msg}");
+        }
+    }
 }
 
 pub async fn get_result(

--- a/tests/server_events_test.rs
+++ b/tests/server_events_test.rs
@@ -41,7 +41,7 @@ fn router_with_immediate_complete() -> axum::Router {
 async fn events_endpoint_streams_complete_event() {
     let app = router_with_immediate_complete();
     let body = serde_json::to_vec(&BuildRequest {
-        nonce: "000102030405060708090a0b0c0d0e0f".into(),
+        nonce: hex::encode(rand::random::<[u8; 16]>()),
         repo_url: Some("https://x".into()),
         repo_ref: None,
         source_data: None,
@@ -123,7 +123,7 @@ async fn events_endpoint_does_not_drop_event_between_snapshot_and_subscribe() {
         .with_state(state);
 
     let body = serde_json::to_vec(&BuildRequest {
-        nonce: "000102030405060708090a0b0c0d0e0f".into(), repo_url: Some("https://x".into()),
+        nonce: hex::encode(rand::random::<[u8; 16]>()), repo_url: Some("https://x".into()),
         repo_ref: None, source_data: None, source_name: None,
     }).unwrap();
     // Use a clone for the POST so `app` is preserved for the events request.

--- a/tests/server_events_test.rs
+++ b/tests/server_events_test.rs
@@ -41,7 +41,7 @@ fn router_with_immediate_complete() -> axum::Router {
 async fn events_endpoint_streams_complete_event() {
     let app = router_with_immediate_complete();
     let body = serde_json::to_vec(&BuildRequest {
-        nonce: "00".into(),
+        nonce: "000102030405060708090a0b0c0d0e0f".into(),
         repo_url: Some("https://x".into()),
         repo_ref: None,
         source_data: None,
@@ -123,7 +123,7 @@ async fn events_endpoint_does_not_drop_event_between_snapshot_and_subscribe() {
         .with_state(state);
 
     let body = serde_json::to_vec(&BuildRequest {
-        nonce: "00".into(), repo_url: Some("https://x".into()),
+        nonce: "000102030405060708090a0b0c0d0e0f".into(), repo_url: Some("https://x".into()),
         repo_ref: None, source_data: None, source_name: None,
     }).unwrap();
     // Use a clone for the POST so `app` is preserved for the events request.

--- a/tests/server_post_build_test.rs
+++ b/tests/server_post_build_test.rs
@@ -12,7 +12,7 @@ fn make_router() -> axum::Router {
 #[tokio::test]
 async fn post_build_returns_job_id() {
     let req = BuildRequest {
-        nonce: "deadbeef".into(),
+        nonce: "000102030405060708090a0b0c0d0e0f".into(),
         repo_url: Some("https://github.com/x/y".into()),
         repo_ref: None,
         source_data: None,
@@ -38,7 +38,7 @@ async fn post_build_returns_job_id() {
 #[tokio::test]
 async fn post_build_second_call_returns_409() {
     let req = BuildRequest {
-        nonce: "00".into(),
+        nonce: "000102030405060708090a0b0c0d0e0f".into(),
         repo_url: Some("https://github.com/x/y".into()),
         repo_ref: None,
         source_data: None,
@@ -104,7 +104,9 @@ async fn post_build_rejects_oversize_nonce() {
 
 #[tokio::test]
 async fn post_build_rejects_missing_source() {
-    let bad = r#"{"nonce":"deadbeef"}"#;
+    // Valid 16-byte nonce so the request is rejected for the missing source,
+    // not for the nonce — that is the path this test is meant to cover.
+    let bad = r#"{"nonce":"000102030405060708090a0b0c0d0e0f"}"#;
     let app = make_router();
     let resp = app
         .oneshot(

--- a/tests/server_result_test.rs
+++ b/tests/server_result_test.rs
@@ -14,7 +14,7 @@ async fn result_endpoint_streams_tarball_when_done() {
     let runner = TestRunner::new();
     let app = router_with_runner_for_tests(runner.clone() as Arc<dyn JobRunner>);
     let body = serde_json::to_vec(&BuildRequest {
-        nonce: "000102030405060708090a0b0c0d0e0f".into(),
+        nonce: hex::encode(rand::random::<[u8; 16]>()),
         repo_url: Some("https://x".into()),
         repo_ref: None,
         source_data: None,

--- a/tests/server_result_test.rs
+++ b/tests/server_result_test.rs
@@ -14,7 +14,7 @@ async fn result_endpoint_streams_tarball_when_done() {
     let runner = TestRunner::new();
     let app = router_with_runner_for_tests(runner.clone() as Arc<dyn JobRunner>);
     let body = serde_json::to_vec(&BuildRequest {
-        nonce: "00".into(),
+        nonce: "000102030405060708090a0b0c0d0e0f".into(),
         repo_url: Some("https://x".into()),
         repo_ref: None,
         source_data: None,


### PR DESCRIPTION
Nonces that happened to have trailing zero bytes by chance would fail to verify, due to the attestation library stripping any trailing null bytes, even if they were actually part of the nonce. This ensures the nonce will be considered 16 bytes at all times, and truncated nonces coming from the attestation library will be padded with zeros until they are 16 bytes to compare.