### PR TITLE
fix(test-integration): use nextest --run-ignored instead of --ignored

### DIFF
--- a/bin/test-integration
+++ b/bin/test-integration
@@ -3,4 +3,4 @@ set -euo pipefail
 
 set -x
 
-cargo nextest run --features attest --ignored all
+cargo nextest run --features attest --run-ignored all


### PR DESCRIPTION
## Problem

`bin/test-integration` invokes:

```
cargo nextest run --features attest --ignored all
```

but cargo-nextest's flag is `--run-ignored`, so the script dies at argument parsing before running anything:

```
error: unexpected argument '--ignored' found

  tip: a similar argument exists: '--run-ignored'
```

(exit code 2). Since this script needs real TEE hardware (SEV-SNP / Azure CVM) and hosted CI skips it, it has plausibly never been executed successfully — the bitrot went unnoticed until confidential-ci's Azure ConfidentialVM lane ran it on real vTPM hardware ([run 29610331659](https://github.com/confidential-dot-ai/confidential-ci/actions/runs/29610331659), 2026-07-17).

## Fix

One line: `--ignored all` → `--run-ignored all`.

## Verification

- `cargo nextest run --features attest --run-ignored all --no-run` — compiles and parses cleanly (no TEE needed).
- `cargo nextest list --features attest --run-ignored all` — enumerates the full suite including the ignored CLI integration tests.
- The old invocation reproduces the exact CI error above with current nextest.