### PR TITLE
ci: run the tee suite on azure-tdx-cvm too

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -153,7 +153,7 @@ jobs:
     strategy:
       fail-fast: false                       # one platform failing must not hide the other
       matrix:
-        runs_on: [snp-metal-cvm, azure-cvm]
+        runs_on: [snp-metal-cvm, azure-cvm, azure-tdx-cvm]
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 45
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -153,7 +153,7 @@ jobs:
     strategy:
       fail-fast: false                       # one platform failing must not hide the other
       matrix:
-        runs_on: [snp-metal-cvm, azure-cvm, azure-tdx-cvm]
+        runs_on: [snp-metal-cvm, azure-snp-cvm, azure-tdx-cvm]
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
## What

Adds `azure-tdx-cvm` to the tee matrix. One token; nothing else changes: the TEE gate already accepts `/dev/tpmrm0`, and `kettle attest` platform-detects (az-tdx probes first, compiled in), so the same suite runs unmodified.

## Context

The runner is the standalone DC4es_v6 TDX CVM in westeurope (confidential-ci `provision-azure-tdx-cvm.yml`; AKS still refuses TDX node pools, [Azure/AKS#5618](https://github.com/Azure/AKS/issues/5618)). Compile constraints carry over unchanged; the node doubles the proven DC2as_v5.

## Caveat

kettle pins attestation to `wasm-verify @ 026cbda` (2026-05-21), whose az_tdx code has never run on real Azure TDX hardware and is two months behind main's TDX fixes. If this cell goes red, suspect the pin before kettle.

Merge after the `azure-tdx-cvm` listener is live.