### PR TITLE
ci: run the tee suite on tdx-metal-cvm too

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -153,15 +153,21 @@ jobs:
     strategy:
       fail-fast: false                       # one platform failing must not hide the other
       matrix:
-        runs_on: [snp-metal-cvm, azure-snp-cvm, azure-tdx-cvm]
+        runs_on: [snp-metal-cvm, azure-snp-cvm, azure-tdx-cvm, tdx-metal-cvm]
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 45
     steps:
       - name: prove the runner is in a real TEE before trusting any result
         run: |
+          # /dev/tdx_guest is checked AFTER /dev/tpmrm0 on purpose: an Azure TDX
+          # guest exposes BOTH, and it attests through the vTPM + IMDS path, so it
+          # must report vTPM. Only bare-metal TDX reaches the tdx_guest branch.
+          # The device node is an underscore; the hyphen spelling is qemu's
+          # -object tdx-guest, which is a host-side string.
           if   [ -e /dev/sev-guest ]; then echo "TEE: native SNP (/dev/sev-guest)"
           elif [ -e /dev/tpmrm0 ];    then echo "TEE: vTPM (/dev/tpmrm0)"
-          else echo "::error::no TEE device (/dev/sev-guest or /dev/tpmrm0) — this runner is not in a CVM"; exit 1; fi
+          elif [ -e /dev/tdx_guest ]; then echo "TEE: native TDX (/dev/tdx_guest)"
+          else echo "::error::no TEE device (/dev/sev-guest, /dev/tpmrm0 or /dev/tdx_guest); this runner is not in a CVM"; exit 1; fi
 
       - name: "build deps (root runner pod: libtss2 + tpm2-tools for --features attest)"
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -186,21 +186,6 @@ jobs:
           curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors https://get.nexte.st/0.9/linux | tar -xz -C /usr/local/bin cargo-nextest
           cargo-nextest --version
 
-      - name: TEMP DIAGNOSTIC, capture the stderr cli_attest_ripgrep swallows
-        if: matrix.runs_on == 'tdx-metal-cvm'
-        continue-on-error: true
-        run: |
-          set -x
-          nproc; free -g; df -h / /tmp
-          cargo build --features attest --bin kettle 2>&1 | tail -4
-          BIN=$(find target -type f -name kettle -perm -u+x | head -1)
-          echo "bin=$BIN"
-          T=$(mktemp -d)
-          git clone --revision cb66736f146f093497f4dc537b33d0826f9af33c https://github.com/burntsushi/ripgrep "$T" 2>&1 | tail -3
-          echo "=== kettle attest (stderr shown) ==="
-          "$BIN" attest "$T" || echo "EXIT=$?"
-          df -h / /tmp
-
       - name: "TEE integration suite (kettle attest → verify, in the guest)"
         env:
           # 4-core/16Gi guest with rke2-on-tmpfs (~5Gi free): cap parallelism +

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -186,6 +186,21 @@ jobs:
           curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors https://get.nexte.st/0.9/linux | tar -xz -C /usr/local/bin cargo-nextest
           cargo-nextest --version
 
+      - name: TEMP DIAGNOSTIC, capture the stderr cli_attest_ripgrep swallows
+        if: matrix.runs_on == 'tdx-metal-cvm'
+        continue-on-error: true
+        run: |
+          set -x
+          nproc; free -g; df -h / /tmp
+          cargo build --features attest --bin kettle 2>&1 | tail -4
+          BIN=$(find target -type f -name kettle -perm -u+x | head -1)
+          echo "bin=$BIN"
+          T=$(mktemp -d)
+          git clone --revision cb66736f146f093497f4dc537b33d0826f9af33c https://github.com/burntsushi/ripgrep "$T" 2>&1 | tail -3
+          echo "=== kettle attest (stderr shown) ==="
+          "$BIN" attest "$T" || echo "EXIT=$?"
+          df -h / /tmp
+
       - name: "TEE integration suite (kettle attest → verify, in the guest)"
         env:
           # 4-core/16Gi guest with rke2-on-tmpfs (~5Gi free): cap parallelism +

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "attestation"
 version = "0.4.0"
-source = "git+https://github.com/confidential-dot-ai/attestation-rs?branch=main#67ee36f86f1618973ddf1dcc5a44cf974acce4f9"
+source = "git+https://github.com/confidential-dot-ai/attestation-rs?branch=wasm-verify#026cbda448cd5786b8e5910024de27dc04d6f1a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -205,8 +205,8 @@ dependencies = [
  "subtle",
  "tempfile",
  "thiserror 2.0.18",
- "time",
  "tokio",
+ "web-time",
  "x509-cert",
  "x509-parser",
  "zerocopy",
@@ -485,7 +485,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1436,7 +1436,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -1677,7 +1677,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2219,7 +2219,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3550,7 +3550,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -4264,7 +4263,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core",
+ "windows-core 0.57.0",
  "windows-targets 0.52.6",
 ]
 
@@ -4274,10 +4273,23 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -4285,6 +4297,17 @@ name = "windows-implement"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4303,6 +4326,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4314,9 +4354,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
- "windows-strings",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -4330,11 +4370,29 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4343,7 +4401,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4370,7 +4428,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4395,7 +4453,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "attestation"
 version = "0.4.0"
-source = "git+https://github.com/confidential-dot-ai/attestation-rs?branch=wasm-verify#026cbda448cd5786b8e5910024de27dc04d6f1a0"
+source = "git+https://github.com/confidential-dot-ai/attestation-rs?branch=main#67ee36f86f1618973ddf1dcc5a44cf974acce4f9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -205,8 +205,8 @@ dependencies = [
  "subtle",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tokio",
- "web-time",
  "x509-cert",
  "x509-parser",
  "zerocopy",
@@ -485,7 +485,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1436,7 +1436,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1677,7 +1677,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2219,7 +2219,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3550,6 +3550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -4263,7 +4264,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.57.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -4273,23 +4274,10 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
+ "windows-implement",
+ "windows-interface",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -4297,17 +4285,6 @@ name = "windows-implement"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4326,23 +4303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4354,9 +4314,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-strings",
 ]
 
 [[package]]
@@ -4370,29 +4330,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -4401,7 +4343,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4428,7 +4370,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4453,7 +4395,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ thiserror = "2.0.18"
 x509-cert = { version = "0.2.5", features = ["std"] }
 uuid = { version = "1.21.0", features = ["v4"] }
 rs_merkle = "1.5.0"
-attestation = { git = "https://github.com/confidential-dot-ai/attestation-rs", branch = "main", version = "0.4.0" }
+attestation = { git = "https://github.com/confidential-dot-ai/attestation-rs", branch = "wasm-verify", version = "0.4.0" }
 tokio = { version = "1.49.0", features = ["rt-multi-thread", "fs"] }
 tracing = "0.1.44"
 clap-verbosity-flag = { version = "3.0.4", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ thiserror = "2.0.18"
 x509-cert = { version = "0.2.5", features = ["std"] }
 uuid = { version = "1.21.0", features = ["v4"] }
 rs_merkle = "1.5.0"
-attestation = { git = "https://github.com/confidential-dot-ai/attestation-rs", branch = "wasm-verify", version = "0.4.0" }
+attestation = { git = "https://github.com/confidential-dot-ai/attestation-rs", branch = "main", version = "0.4.0" }
 tokio = { version = "1.49.0", features = ["rt-multi-thread", "fs"] }
 tracing = "0.1.44"
 clap-verbosity-flag = { version = "3.0.4", default-features = false, features = [

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -458,6 +458,14 @@ mod tests {
             init_data_match: None,
             collateral_verified: true,
             tcb_status: None,
+            // All None for SNP: these are the TDX measurement compares, plus
+            // launch_digest_match which needs an expected value to compare against.
+            mrtd_match: None,
+            rtmr0_match: None,
+            rtmr1_match: None,
+            rtmr2_match: None,
+            rtmr3_match: None,
+            launch_digest_match: None,
         }
     }
 

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -458,14 +458,6 @@ mod tests {
             init_data_match: None,
             collateral_verified: true,
             tcb_status: None,
-            // All None for SNP: these are the TDX measurement compares, plus
-            // launch_digest_match which needs an expected value to compare against.
-            mrtd_match: None,
-            rtmr0_match: None,
-            rtmr1_match: None,
-            rtmr2_match: None,
-            rtmr3_match: None,
-            launch_digest_match: None,
         }
     }
 

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -141,13 +141,7 @@ fn cli_attest_ripgrep() -> anyhow::Result<()> {
         .output()
         .expect("failed to kettle attest");
 
-    assert!(
-        output.status.success(),
-        "kettle attest failed: status={:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
-        output.status,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    );
+    assert!(output.status.success());
 
     let build_dir = tmp.path().join("kettle-build");
     let output = Command::new(kettle_bin())
@@ -155,13 +149,7 @@ fn cli_attest_ripgrep() -> anyhow::Result<()> {
         .output()
         .expect("failed to kettle verify");
 
-    assert!(
-        output.status.success(),
-        "kettle verify failed: status={:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
-        output.status,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    );
+    assert!(output.status.success());
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
@@ -197,13 +185,7 @@ fn cli_attest_alejandra() -> anyhow::Result<()> {
         .output()
         .expect("failed to kettle attest");
 
-    assert!(
-        output.status.success(),
-        "kettle attest failed: status={:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
-        output.status,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    );
+    assert!(output.status.success());
 
     let build_dir = tmp.path().join("kettle-build");
     let output = Command::new(kettle_bin())
@@ -211,13 +193,7 @@ fn cli_attest_alejandra() -> anyhow::Result<()> {
         .output()
         .expect("failed to kettle verify");
 
-    assert!(
-        output.status.success(),
-        "kettle verify failed: status={:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
-        output.status,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    );
+    assert!(output.status.success());
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -141,7 +141,13 @@ fn cli_attest_ripgrep() -> anyhow::Result<()> {
         .output()
         .expect("failed to kettle attest");
 
-    assert!(output.status.success());
+    assert!(
+        output.status.success(),
+        "kettle attest failed: status={:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
 
     let build_dir = tmp.path().join("kettle-build");
     let output = Command::new(kettle_bin())
@@ -185,7 +191,13 @@ fn cli_attest_alejandra() -> anyhow::Result<()> {
         .output()
         .expect("failed to kettle attest");
 
-    assert!(output.status.success());
+    assert!(
+        output.status.success(),
+        "kettle attest failed: status={:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
 
     let build_dir = tmp.path().join("kettle-build");
     let output = Command::new(kettle_bin())

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -155,7 +155,13 @@ fn cli_attest_ripgrep() -> anyhow::Result<()> {
         .output()
         .expect("failed to kettle verify");
 
-    assert!(output.status.success());
+    assert!(
+        output.status.success(),
+        "kettle verify failed: status={:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
@@ -205,7 +211,13 @@ fn cli_attest_alejandra() -> anyhow::Result<()> {
         .output()
         .expect("failed to kettle verify");
 
-    assert!(output.status.success());
+    assert!(
+        output.status.success(),
+        "kettle verify failed: status={:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(


### PR DESCRIPTION
Adds the fourth cell to the `tee` matrix, now that the `tdx-metal-cvm` runner exists.

The runner is the in-guest ARC scale set from confidential-ci `provision-tdx-metal-cvm.yml`, standing on `tdx-gh-runner` and scaling to zero at idle. The runner pod runs inside the TD, so the suite builds and runs as plain steps on the same rail as the other three cells. The suite is platform agnostic here, so the cell is just the runner label plus a device branch.

## Why `/dev/tdx_guest` is checked after `/dev/tpmrm0`

An Azure TDX guest exposes **both** devices and attests through the vTPM + IMDS path, so it has to keep reporting vTPM. Only bare-metal TDX should reach the `tdx_guest` branch. Reversing the order would silently relabel the existing `azure-tdx-cvm` cell as native TDX while it is still attesting over the vTPM.

The device node is an underscore. The hyphen spelling is qemu's `-object tdx-guest`, a host-side string.

## Pre-merge validation

`e2e.yml` is `push:main` + `workflow_dispatch`, never `pull_request`, since these are org self-hosted confidential runners. I dispatched it on this branch so the cell is proven before merge rather than after; result linked in a comment below.
