### PR TITLE
fix: track attestation-rs main instead of the stale wasm-verify branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "attestation"
 version = "0.4.0"
-source = "git+https://github.com/confidential-dot-ai/attestation-rs?branch=wasm-verify#026cbda448cd5786b8e5910024de27dc04d6f1a0"
+source = "git+https://github.com/confidential-dot-ai/attestation-rs?branch=main#67ee36f86f1618973ddf1dcc5a44cf974acce4f9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -205,8 +205,8 @@ dependencies = [
  "subtle",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tokio",
- "web-time",
  "x509-cert",
  "x509-parser",
  "zerocopy",
@@ -485,7 +485,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1436,7 +1436,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1677,7 +1677,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2219,7 +2219,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3550,6 +3550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -4263,7 +4264,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.57.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -4273,23 +4274,10 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
+ "windows-implement",
+ "windows-interface",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -4297,17 +4285,6 @@ name = "windows-implement"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4326,23 +4303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4354,9 +4314,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-strings",
 ]
 
 [[package]]
@@ -4370,29 +4330,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -4401,7 +4343,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4428,7 +4370,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4453,7 +4395,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ thiserror = "2.0.18"
 x509-cert = { version = "0.2.5", features = ["std"] }
 uuid = { version = "1.21.0", features = ["v4"] }
 rs_merkle = "1.5.0"
-attestation = { git = "https://github.com/confidential-dot-ai/attestation-rs", branch = "wasm-verify", version = "0.4.0" }
+attestation = { git = "https://github.com/confidential-dot-ai/attestation-rs", branch = "main", version = "0.4.0" }
 tokio = { version = "1.49.0", features = ["rt-multi-thread", "fs"] }
 tracing = "0.1.44"
 clap-verbosity-flag = { version = "3.0.4", default-features = false, features = [

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -458,6 +458,14 @@ mod tests {
             init_data_match: None,
             collateral_verified: true,
             tcb_status: None,
+            // All None for SNP: these are the TDX measurement compares, plus
+            // launch_digest_match which needs an expected value to compare against.
+            mrtd_match: None,
+            rtmr0_match: None,
+            rtmr1_match: None,
+            rtmr2_match: None,
+            rtmr3_match: None,
+            launch_digest_match: None,
         }
     }
 


### PR DESCRIPTION
Fixes #56.

## The pin was stale

`Cargo.toml` pinned `attestation` to `branch = "wasm-verify"` at `026cbda4` (2026-05-21), which is **122 commits behind main**. That branch existed to develop the `attestation-wasm` crate. That crate now lives on main at `crates/attestation-wasm`, and the only three commits unique to the branch are the ones that built it, so nothing kettle depends on is exclusive to it.

## Why it matters beyond hygiene

The stale pin makes `kettle verify` **fail on bare-metal Intel TDX**. The old CCEL replay compares all four RTMRs and treats any mismatch as fatal:

```rust
let expected = [rtmr_0, rtmr_1, rtmr_2, rtmr_3];   // 026cbda4
```

But RTMR[3] is the runtime-extendable register, and runtime extends never appear in the CCEL, which is a firmware-produced ACPI table. On the c8s TDX node image the initrd extends RTMR[3] with the operator-key binding after firmware handoff, so replay yields zeros against a real hardware value and verification fails:

```
eventlog integrity check failed: RTMR[3] mismatch:
  replayed=0000...0000
  expected=5d65d032a54ffb6b...
```

main already fixed this. It enforces RTMR[0-2], downgrades RTMR[3] to a `log::warn!`, and documents why:

> Only RTMR[0-2] (boot-time registers) are subject to this check. RTMR[3] ... makes RTMR[3] unreplayable by construction. Relying parties verify `quote.rtmr_3` directly.

This is not a loosening. main additionally exposes the compare as an `rtmr3_match` field, so the check moves to where it can actually be evaluated rather than being asserted against a log that structurally cannot contain it.

## The one API break

`VerificationResult` gained six `Option<bool>` compare fields upstream (`mrtd_match`, `rtmr0_match`..`rtmr3_match`, `launch_digest_match`). The only breakage was a single test helper that builds the struct literally; all six are `None` for the SNP result it constructs.

## Verification

- `cargo clippy --all-targets` with `RUSTFLAGS="-D warnings"`: clean
- `cargo test`: **188 passed, 0 failed**
- Dependency delta is otherwise a reduction (drops six now-unused `windows-*` crates)

Bare-metal TDX validation runs on the `tdx-metal-cvm` runner from #55, which is where the failure was found.
