### PR TITLE
ci: attest the metal standing runners per run, off the runner

### DIFF
--- a/.github/workflows/attest-runner.yml
+++ b/.github/workflows/attest-runner.yml
@@ -1,0 +1,182 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# VENDORED FROM confidential-ci. KEEP BYTE-IDENTICAL BELOW THIS BANNER.
+# ═══════════════════════════════════════════════════════════════════════════
+# SOURCE OF TRUTH: confidential-dot-ai/confidential-ci
+#                  .github/workflows/attest-runner.yml
+#
+# This repo is public and confidential-ci is private, so `uses:` cannot reach
+# the original. Edit the original, then copy the whole file across.
+#
+# ═══════════════════════════════════════════════════════════════════════════
+# ATTEST A SELF-HOSTED CONFIDENTIAL RUNNER, PER JOB, TO SOMETHING THAT IS NOT
+# THE RUNNER.
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# WHAT THIS REPLACES. Consumer lanes gate on `[ -e /dev/sev-guest ]` before
+# trusting a result. That check is made by the guest, about the guest, and it
+# passes whenever a device node exists. A standing runner is attested once when
+# it is provisioned and every job after that inherits the same evidence, so the
+# interval between provisioning and a job is unmeasured. See issue #51.
+#
+# THE TWO PROPERTIES THAT MATTER, and neither is achievable inside the guest:
+#
+#   FRESHNESS.   The nonce is generated in a job that does not run on the
+#                runner. If the guest chose its own nonce, a genuine report
+#                captured from an earlier boot would satisfy the check forever.
+#
+#   EXTERNALITY. The report is verified in a job that does not run on the
+#                runner. A guest asserting its own verification result is the
+#                circular check this is meant to remove.
+#
+# WHAT IT PROVES. That at the moment this job ran, the runner label reached a TEE
+# that produced a report over this job's nonce, carrying the launch measurement
+# the caller pinned, with a valid signature over that report.
+#
+# WHAT IT DOES NOT PROVE, and the first run is what showed this. The report comes
+# back `"collateral_verified": false`, because attestation-cli takes no cert
+# provider and so never fetches the AMD or Intel chain. The signature is checked
+# against the certificate carried in the evidence, and nothing checks that the
+# certificate itself descends from the vendor root. Closing that needs either a
+# provider option on the CLI or the attesting side embedding a fetched VCEK, and
+# until then this gate is weaker than a full remote-attestation check.
+#
+# WHAT IT DOES NOT PROVE. A launch measurement covers the boot chain. It does
+# not cover software installed after boot, which on a standing runner includes
+# the CI agent itself, and it does not cover what a previous job left behind.
+# Closing that needs a runtime measurement of post-boot state, which SEV-SNP has
+# no register for. This narrows the interval; it does not eliminate the class.
+name: attest-runner
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'runner label to attest, for example snp-metal-cvm'
+        required: true
+        type: string
+      platform:
+        description: 'attestation-cli platform: snp | tdx | az-snp | az-tdx'
+        required: true
+        type: string
+      expected_launch_digest:
+        description: 'SNP launch digest, hex, 48 bytes. Empty checks genuineness and freshness only.'
+        required: false
+        type: string
+        default: ''
+      expected_mrtd:
+        description: 'TDX MRTD, hex, 48 bytes. Empty checks genuineness and freshness only.'
+        required: false
+        type: string
+        default: ''
+      cli_ref:
+        description: 'attestation-rs ref to build the verifier from'
+        required: false
+        type: string
+        default: 'main'
+
+permissions:
+  contents: read
+
+jobs:
+  nonce:
+    # Deliberately ubuntu-latest. The value of the nonce is entirely in the fact
+    # that the runner being attested did not choose it.
+    name: pick a nonce off the runner
+    runs-on: ubuntu-latest
+    outputs:
+      nonce: ${{ steps.gen.outputs.nonce }}
+    steps:
+      - id: gen
+        run: |
+          set -euo pipefail
+          # 64 bytes, because that is the width of the guest-supplied field in
+          # both an SNP report and a TDX quote.
+          NONCE=$(head -c 64 /dev/urandom | od -An -tx1 | tr -d ' \n')
+          echo "nonce=$NONCE" >> "$GITHUB_OUTPUT"
+          echo "nonce chosen off the runner: ${NONCE:0:16}..."
+
+  evidence:
+    name: produce evidence on ${{ inputs.runner }}
+    needs: nonce
+    runs-on: ${{ inputs.runner }}
+    outputs:
+      evidence: ${{ steps.att.outputs.evidence }}
+    steps:
+      - name: build deps
+        run: |
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update -qq
+          apt-get install -y -qq --no-install-recommends \
+            libtss2-dev pkg-config build-essential curl ca-certificates git
+
+      # No rust-cache. There is no workspace checked out here, so its post step
+      # fails looking for a Cargo.toml, and `cargo install --git` would not use
+      # the workspace cache anyway.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: attest over the caller's nonce
+        id: att
+        env:
+          NONCE: ${{ needs.nonce.outputs.nonce }}
+        run: |
+          set -euo pipefail
+          cargo install --quiet \
+            --git https://github.com/confidential-dot-ai/attestation-rs \
+            --rev "${{ inputs.cli_ref }}" \
+            --features attest attestation-cli 2>/dev/null \
+            || cargo install --quiet \
+                 --git https://github.com/confidential-dot-ai/attestation-rs \
+                 --branch "${{ inputs.cli_ref }}" \
+                 --features attest attestation-cli
+          attestation-cli attest \
+            --platform '${{ inputs.platform }}' \
+            --report-data-hex "$NONCE" > /tmp/evidence.json
+          # Carried as a job output rather than an artifact so the verify job
+          # cannot be handed a different file than the one this job produced.
+          echo "evidence=$(base64 -w0 < /tmp/evidence.json)" >> "$GITHUB_OUTPUT"
+          echo "evidence produced, $(wc -c < /tmp/evidence.json) bytes"
+
+  verify:
+    # Deliberately ubuntu-latest, and deliberately a separate job. A guest that
+    # verified its own report and reported the outcome would be asserting its own
+    # trustworthiness, which is the thing being removed.
+    name: verify off the runner
+    needs: [nonce, evidence]
+    runs-on: ubuntu-latest
+    steps:
+      - name: build deps
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends libtss2-dev pkg-config build-essential
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: verify the report against the nonce and the pinned measurement
+        env:
+          NONCE: ${{ needs.nonce.outputs.nonce }}
+          EVIDENCE: ${{ needs.evidence.outputs.evidence }}
+          LAUNCH: ${{ inputs.expected_launch_digest }}
+          MRTD: ${{ inputs.expected_mrtd }}
+        run: |
+          set -euo pipefail
+          # No --features attest here on purpose. This host has no TEE and the
+          # verify path does not need one, so the verifier cannot accidentally
+          # depend on hardware it is checking claims about.
+          cargo install --quiet \
+            --git https://github.com/confidential-dot-ai/attestation-rs \
+            --branch "${{ inputs.cli_ref }}" attestation-cli
+          printf '%s' "$EVIDENCE" | base64 -d > /tmp/evidence.json
+
+          ARGS=(verify --evidence /tmp/evidence.json --expected-report-data "$NONCE")
+          if [ -n "$LAUNCH" ]; then
+            ARGS+=(--expected-launch-digest "$LAUNCH")
+          elif [ -n "$MRTD" ]; then
+            ARGS+=(--expected-mrtd "$MRTD")
+          else
+            echo "::warning title=no measurement pinned::Checked that the report is genuine and fresh, but not that it came from the image we expect. Pass expected_launch_digest or expected_mrtd to close that."
+          fi
+
+          attestation-cli "${ARGS[@]}"
+          echo "runner ${{ inputs.runner }} attested off-runner, bound to this job's nonce"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -158,6 +158,14 @@ jobs:
   # instrument. The TDX node image is console-dead by design and the
   # provisioner discards the operator key, so a signed report is the only
   # evidence anyone can get about that guest after provisioning.
+  attest-snp-metal:
+    uses: ./.github/workflows/attest-runner.yml
+    with:
+      runner: snp-metal-cvm
+      platform: snp
+      # Same value the ephemeral c8s lane pins, so it is already known good.
+      expected_launch_digest: '15bc995383ddcf1fee2107753e6c26bc65358602519a342b8ff8fbfdfa4b40865d90b11cef11b7d34934e6c5eed19115'
+
   attest-tdx-metal:
     uses: ./.github/workflows/attest-runner.yml
     with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -149,6 +149,23 @@ jobs:
             exit 1
           fi
 
+  # ── PER-JOB ATTESTATION OF THE STANDING RUNNER ───────────────────────────
+  # Runs alongside `tee`, not in front of it. A green run therefore means both
+  # that the suite passed and that an attested environment answered to this
+  # label for this run, rather than only the first.
+  #
+  # Wired for tdx-metal first because it is the runner with no other
+  # instrument. The TDX node image is console-dead by design and the
+  # provisioner discards the operator key, so a signed report is the only
+  # evidence anyone can get about that guest after provisioning.
+  attest-tdx-metal:
+    uses: ./.github/workflows/attest-runner.yml
+    with:
+      runner: tdx-metal-cvm
+      platform: tdx
+      # Published in the tdx-rke2-image-refs ConfigMap alongside the node image.
+      expected_mrtd: '9309eaae9c151e766de0f97b1d1aaeb76b8c8c366080803943fb566521c8f0cf00a142d8b7b0683ed1d42c5a27198ba1'
+
   tee:
     strategy:
       fail-fast: false                       # one platform failing must not hide the other


### PR DESCRIPTION
The tee cells gate on a device node existing. That check is made by the guest, about the guest, and the standing runners behind those labels are attested once when provisioned, with every job after inheriting that same evidence.

This adds a per-run attestation for `tdx-metal-cvm`. A nonce is chosen on a GitHub-hosted runner, the report is produced on the standing runner, and the report is verified on a GitHub-hosted runner against the nonce and the MRTD published in the `tdx-rke2-image-refs` ConfigMap.

**Validated on this branch**: [run 30319696261](https://github.com/confidential-dot-ai/kettle/actions/runs/30319696261), all three attestation jobs green, zero warning annotations (so the MRTD pin engaged rather than falling through to the genuineness-only path), and `tee (tdx-metal-cvm)` green alongside it.

## Why TDX first

It is the runner with no other instrument. The node image is console-dead by design and the provisioner discards the operator key, so a signed report is the only evidence obtainable about that guest once provisioning ends.

## Why it runs alongside `tee` rather than in front

Simpler, no matrix coupling, and a green run means both that the suite passed and that an attested environment answered to this label for this run.

## What it does not prove

The attest job and the tee job get separate ephemeral runner pods on the same standing guest. This establishes that an attested environment answered to the label around the time of the run, not that the tests executed inside the environment that was attested. It narrows the unmeasured window from since-provisioning to minutes rather than eliminating it. The stronger form emits evidence from inside the test job and verifies it afterwards, which inverts the flow from gate-then-test to test-then-judge.

It also does not verify the vendor certificate chain. `attestation-cli` takes no cert provider, so reports come back `collateral_verified: false`. See confidential-ci#51 and #53.

Deliberately scoped to one cell. The remaining seven are worth wiring only after the shape above is settled, otherwise they are rework.

Vendored because this repo is public and confidential-ci is private.