### PR TITLE
ci: correct what collateral_verified: false means in attest-runner

### DIFF
--- a/.github/workflows/attest-runner.yml
+++ b/.github/workflows/attest-runner.yml
@@ -32,13 +32,14 @@
 # that produced a report over this job's nonce, carrying the launch measurement
 # the caller pinned, with a valid signature over that report.
 #
-# WHAT IT DOES NOT PROVE, and the first run is what showed this. The report comes
-# back `"collateral_verified": false`, because attestation-cli takes no cert
-# provider and so never fetches the AMD or Intel chain. The signature is checked
-# against the certificate carried in the evidence, and nothing checks that the
-# certificate itself descends from the vendor root. Closing that needs either a
-# provider option on the CLI or the attesting side embedding a fetched VCEK, and
-# until then this gate is weaker than a full remote-attestation check.
+# WHAT IT DOES NOT PROVE, and what `"collateral_verified": false` on the SNP
+# lanes actually means. The flag does not mean the chain is unchecked: the CLI
+# verifies with its default providers, which embed the AMD root keys and walk
+# each report's VCEK back to them, and the TDX lanes fetch Intel's collateral
+# in full, revocation included. What `false` means is that revocation is
+# skipped on SNP: the default provider fetches no AMD CRL, so a chip key AMD
+# has revoked would still pass. Closing that needs a CRL-fetching cert
+# provider on the verify side, like the one attestation-api already carries.
 #
 # WHAT IT DOES NOT PROVE. A launch measurement covers the boot chain. It does
 # not cover software installed after boot, which on a standing runner includes


### PR DESCRIPTION
The header claimed attestation-cli takes no cert provider and never fetches the AMD or Intel chain, so nothing ties the evidence certificate to a vendor root. The code disagrees:

- `cmd_verify` builds the verifier with `DefaultCertProvider` and `DefaultTdxCollateralProvider` (attestation-rs `lib.rs`)
- the AMD ARK and ASK roots are embedded, and each SNP report's VCEK is verified back to them (`snp/verify.rs`)
- the TDX lanes fetch Intel PCS collateral in full: TCB info, QE identity, PCK CRL, root CA CRL (`collateral.rs`)
- per `types.rs`, `collateral_verified: false` means one thing: the revocation check was skipped, which on SNP is guaranteed because the default provider fetches no AMD CRL

So the gate is stronger than the header admitted, and the actual gap is narrower: a chip key AMD has revoked would still pass on the SNP lanes. The header now states that, and names the fix (a CRL-fetching cert provider on the verify side, like the one attestation-api already carries).

Comment-only change. No behavior difference, no job or step edits.

Vendored copy: banner untouched, byte-identical below it to the confidential-ci source carrying the same fix (confidential-dot-ai/confidential-ci PR of the same branch name).